### PR TITLE
Add a method to parse authentication result

### DIFF
--- a/app/src/main/java/com/ifttt/api/demo/MainActivity.kt
+++ b/app/src/main/java/com/ifttt/api/demo/MainActivity.kt
@@ -3,21 +3,21 @@ package com.ifttt.api.demo
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.EditText
 import android.widget.LinearLayout
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
+import com.ifttt.Applet
+import com.ifttt.ErrorResponse
 import com.ifttt.IftttApiClient
 import com.ifttt.api.PendingResult
 import com.ifttt.api.demo.api.ApiHelper
 import com.ifttt.api.demo.api.ApiHelper.fetchIftttToken
-import com.ifttt.Applet
-import com.ifttt.ErrorResponse
 
 class MainActivity : AppCompatActivity() {
 
@@ -110,15 +110,9 @@ class MainActivity : AppCompatActivity() {
             // In case at this point your app doesn't have IFTTT token, you want to fetch the token again before
             // refreshing the UI. This is to make sure the IFTTT token is attached to IftttApiClient and the Applets
             // retrieved have user status.
-            fetchIftttToken({ token ->
-                if (token != null) {
-                    iftttApiClient.setUserToken(token)
-                }
-                renderUi()
-            }, {
-                Snackbar.make(findViewById<View>(android.R.id.content), R.string.user_auth_error,
-                        Snackbar.LENGTH_LONG).show()
-            })
+            iftttApiClient.getResultFromIntent(
+                    { fetchIftttToken({ token -> it.onTokenRetrieved(token) }, { /* No-op */ }) }, intent,
+                    { renderUi() })
         }
     }
 

--- a/ifttt-sdk-android/src/main/java/com/ifttt/AppletAuthenticationResult.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/AppletAuthenticationResult.java
@@ -1,0 +1,9 @@
+package com.ifttt;
+
+public final class AppletAuthenticationResult {
+    public final boolean successful;
+
+    AppletAuthenticationResult(boolean successful) {
+        this.successful = successful;
+    }
+}

--- a/ifttt-sdk-android/src/main/java/com/ifttt/IftttApiClient.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/IftttApiClient.java
@@ -1,5 +1,6 @@
 package com.ifttt;
 
+import android.content.Intent;
 import com.ifttt.api.AppletConfigApi;
 import com.ifttt.api.AppletsApi;
 import com.ifttt.api.PendingResult;
@@ -30,6 +31,17 @@ import retrofit2.converter.moshi.MoshiConverterFactory;
  * </ul>
  */
 public final class IftttApiClient {
+
+    /**
+     * Interface for retrieving Applet authentication result from the web view or IFTTT app.
+     */
+    public interface AppletAuthenticationResultCallback {
+
+        /**
+         * @param result
+         */
+        void onResult(AppletAuthenticationResult result);
+    }
 
     static final String ANONYMOUS_ID = UUID.randomUUID().toString();
 
@@ -123,6 +135,20 @@ public final class IftttApiClient {
      */
     public void clearInviteCode() {
         inviteCodeInterceptor.setInviteCode(null);
+    }
+
+
+    public void getResultFromIntent(UserTokenProvider userTokenProvider, Intent intent,
+            AppletAuthenticationResultCallback callback) {
+
+        userTokenProvider.getUserToken(token -> {
+            if (token != null) {
+                tokenInterceptor.setToken(token);
+            }
+
+            // TODO: Parse result from deep link intent.
+            callback.onResult(new AppletAuthenticationResult(false));
+        });
     }
 
     public static IftttApiClient getInstance() {

--- a/ifttt-sdk-android/src/main/java/com/ifttt/UserTokenProvider.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/UserTokenProvider.java
@@ -1,0 +1,11 @@
+package com.ifttt;
+
+import javax.annotation.Nullable;
+
+public interface UserTokenProvider {
+    interface Callback {
+        void onTokenRetrieved(@Nullable String token);
+    }
+
+    void getUserToken(Callback callback);
+}


### PR DESCRIPTION
The method will enforce clients to pass in a UserTokenProvider, the
intention being that we want the clients to try to fetch the user token
through a secure way, and set up the IftttApiClient so that the
IftttConnectButton can allow users to toggle the Applet.