### PR TITLE
Add support for Android 4.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "com.ifttt.api.demo"
-        minSdkVersion 19
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.0'
     repositories {
         google()
         jcenter()

--- a/ifttt-sdk-android/build.gradle
+++ b/ifttt-sdk-android/build.gradle
@@ -9,7 +9,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode 1
         versionName "2.0.0-alpha1"

--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/ButtonApiHelper.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/ButtonApiHelper.java
@@ -1,9 +1,11 @@
 package com.ifttt.ui;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
@@ -64,11 +66,15 @@ final class ButtonApiHelper {
         });
     }
 
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+    void redirectToWebCompat(Context context, Applet applet) {
+        CustomTabsIntent intent = new CustomTabsIntent.Builder().build();
+        intent.launchUrl(context, Uri.parse(applet.embeddedUrl));
+    }
+
     void redirectToWeb(Context context, Applet applet, String email, ButtonState buttonState) {
         Uri uri = getEmbedUri(applet, buttonState, redirectUri, email, opaqueToken, inviteCode);
-        CustomTabsIntent intent =
-                new CustomTabsIntent.Builder().setToolbarColor(applet.getPrimaryService().brandColor).build();
-
+        CustomTabsIntent intent = new CustomTabsIntent.Builder().build();
         intent.launchUrl(context, uri);
     }
 

--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
@@ -50,6 +50,8 @@ import com.ifttt.api.PendingResult.ResultCallback;
 import javax.annotation.Nullable;
 
 import static android.graphics.Color.BLACK;
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 import static androidx.lifecycle.Lifecycle.State.CREATED;
@@ -63,6 +65,8 @@ import static com.ifttt.ui.ButtonUiHelper.buildStateListButtonBackground;
 import static com.ifttt.ui.ButtonUiHelper.getDarkerColor;
 import static com.ifttt.ui.ButtonUiHelper.getTextTransitionAnimator;
 import static com.ifttt.ui.ButtonUiHelper.replaceKeyWithImage;
+import static com.ifttt.ui.ButtonUiHelper.setProgressBackgroundColor;
+import static com.ifttt.ui.ButtonUiHelper.setProgressBackgroundProgress;
 import static com.ifttt.ui.ButtonUiHelper.setTextSwitcherText;
 import static com.ifttt.ui.IftttConnectButton.ButtonState.CreateAccount;
 import static com.ifttt.ui.IftttConnectButton.ButtonState.Enabled;
@@ -259,9 +263,13 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
         buttonRoot = findViewById(R.id.ifttt_toggle);
 
         progressRoot = findViewById(R.id.ifttt_progress_container);
-        ProgressBackgroundDrawable progressRootBg = new ProgressBackgroundDrawable();
-        progressRootBg.setColor(ContextCompat.getColor(context, R.color.ifttt_progress_background_color), BLACK);
-        progressRoot.setBackground(progressRootBg);
+        if (SDK_INT >= KITKAT) {
+            // Only use ProgressBackgroundDrawable on Android 19 or above.
+            ProgressBackgroundDrawable progressRootBg = new ProgressBackgroundDrawable();
+            progressRootBg.setColor(ContextCompat.getColor(getContext(), R.color.ifttt_progress_background_color),
+                    BLACK);
+            progressRoot.setBackground(progressRootBg);
+        }
 
         progressTxt = findViewById(R.id.ifttt_progress_text);
         progressTxt.setTypeface(boldTypeface);
@@ -470,7 +478,11 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
 
             @Override
             public void onAnimationEnd(Animator animation) {
-                setTextSwitcherText(helperTxt, poweredByIfttt);
+                if (applet.status == enabled) {
+                    setTextSwitcherText(helperTxt, manageApplets);
+                } else {
+                    setTextSwitcherText(helperTxt, poweredByIfttt);
+                }
             }
         });
         fadeInButtonRoot.start();
@@ -478,7 +490,6 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
         final Context context = getContext();
         if (applet.status != Applet.Status.enabled) {
             recordState(Initial);
-            buttonRoot.setBackground(buildButtonBackground(context, BLACK));
 
             String signInText = getResources().getString(R.string.ifttt_connect_to, worksWithService.name);
             if (signInText.length() > MAX_LENGTH) {
@@ -487,7 +498,6 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
                 connectStateTxt.setText(signInText);
             }
 
-            setTextSwitcherText(helperTxt, poweredByIfttt);
             helperTxt.setClickable(true);
             iconDragHelperCallback.setDragEnabled(false);
         } else {
@@ -504,7 +514,6 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
             float progress = 1f;
             setConnectTextState(progress, enabledText, disabledText);
 
-            setTextSwitcherText(helperTxt, manageApplets);
             helperTxt.setOnClickListener(v -> buttonApiHelper.redirectToPlayStore(context));
         }
 
@@ -540,7 +549,10 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
         lp.gravity = applet.status == enabled ? Gravity.END : Gravity.START;
         iconImg.setLayoutParams(lp);
 
-        if (applet.status == enabled) {
+        if (SDK_INT < KITKAT) {
+            // On Jelly Bean, the click events on the button will only take users out to the browser.
+            buttonRoot.setOnClickListener(v -> buttonApiHelper.redirectToWebCompat(context, applet));
+        } else if (applet.status == enabled) {
             buttonRoot.setOnClickListener(
                     v -> setTextSwitcherText(helperTxt, getResources().getString(R.string.slide_to_turn_off)));
         } else {
@@ -644,10 +656,8 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
 
         ValueAnimator showProgress = ValueAnimator.ofFloat(0f, 0.5f).setDuration(ANIM_DURATION_LONG);
         showProgress.setInterpolator(LINEAR_INTERPOLATOR);
-        showProgress.addUpdateListener(animation -> {
-            float progress = (float) animation.getAnimatedValue();
-            ((ProgressBackgroundDrawable) progressRoot.getBackground()).setProgress(progress);
-        });
+        showProgress.addUpdateListener(animation -> setProgressBackgroundProgress(progressRoot.getBackground(),
+                (float) animation.getAnimatedValue()));
 
         ObjectAnimator fadeInProgressContainer = ObjectAnimator.ofFloat(progressRoot, "alpha", 0f, 1f);
         fadeInProgressContainer.addListener(new AnimatorListenerAdapter() {
@@ -707,10 +717,9 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
     }
 
     private Animator getCompleteEmailValidationAnimator() {
-        ValueAnimator.AnimatorUpdateListener updateListener = animation -> {
-            float progress = (float) animation.getAnimatedValue();
-            ((ProgressBackgroundDrawable) progressRoot.getBackground()).setProgress(progress);
-        };
+        ValueAnimator.AnimatorUpdateListener updateListener =
+                animation -> setProgressBackgroundProgress(progressRoot.getBackground(),
+                        (float) animation.getAnimatedValue());
 
         ValueAnimator complete = ValueAnimator.ofFloat(0.5f, 1f).setDuration(ANIM_DURATION_LONG);
         complete.setInterpolator(LINEAR_INTERPOLATOR);
@@ -855,7 +864,7 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
         set.addListener(new AnimatorListenerAdapter() {
             @Override
             public void onAnimationStart(Animator animation) {
-                ((ProgressBackgroundDrawable) progressRoot.getBackground()).setColor(worksWithService.brandColor,
+                setProgressBackgroundColor(progressRoot.getBackground(), worksWithService.brandColor,
                         worksWithService.brandColor);
             }
         });
@@ -884,9 +893,8 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
         });
 
         ValueAnimator completeProgress = ValueAnimator.ofFloat(0f, 1f);
-        completeProgress.addUpdateListener(
-                animation -> ((ProgressBackgroundDrawable) progressRoot.getBackground()).setProgress(
-                        (Float) animation.getAnimatedValue()));
+        completeProgress.addUpdateListener(animation -> setProgressBackgroundProgress(progressRoot.getBackground(),
+                (float) animation.getAnimatedValue()));
         completeProgress.setDuration(ANIM_DURATION_LONG);
         completeProgress.setInterpolator(EASE_INTERPOLATOR);
 
@@ -915,9 +923,8 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
         set.addListener(new AnimatorListenerAdapter() {
             @Override
             public void onAnimationStart(Animator animation) {
-                ProgressBackgroundDrawable progressContainerBg =
-                        (ProgressBackgroundDrawable) progressRoot.getBackground();
-                progressContainerBg.setColor(worksWithService.brandColor, getDarkerColor(worksWithService.brandColor));
+                setProgressBackgroundColor(progressRoot.getBackground(), worksWithService.brandColor,
+                        getDarkerColor(worksWithService.brandColor));
                 ImageLoader.get()
                         .load(IftttConnectButton.this, worksWithService.monochromeIconUrl, iconSize, bitmap -> {
                             if (bitmap != null) {

--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/ProgressBackgroundDrawable.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/ProgressBackgroundDrawable.java
@@ -10,10 +10,13 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.shapes.PathShape;
 import android.graphics.drawable.shapes.RoundRectShape;
+import android.os.Build;
 import androidx.annotation.ColorInt;
 import androidx.annotation.FloatRange;
+import androidx.annotation.RequiresApi;
 import javax.annotation.Nullable;
 
+@RequiresApi(Build.VERSION_CODES.KITKAT)
 final class ProgressBackgroundDrawable extends Drawable {
 
     private final Path progressPath = new Path();

--- a/ifttt-sdk-android/src/main/res/drawable/background_button.xml
+++ b/ifttt-sdk-android/src/main/res/drawable/background_button.xml
@@ -4,4 +4,5 @@
 
     <size android:height="@dimen/connect_button_height"/>
     <corners android:radius="@dimen/connect_button_radius"/>
+    <solid android:color="@android:color/black" />
 </shape>

--- a/ifttt-sdk-android/src/main/res/layout/view_ifttt_about.xml
+++ b/ifttt-sdk-android/src/main/res/layout/view_ifttt_about.xml
@@ -14,8 +14,8 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="48dp"
-            android:layout_marginStart="48dp"
+            android:paddingLeft="48dp"
+            android:paddingRight="48dp"
             android:gravity="center"
             android:orientation="vertical">
 

--- a/ifttt-sdk-android/src/main/res/values-v21/colors.xml
+++ b/ifttt-sdk-android/src/main/res/values-v21/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ifttt_background_touch_color">#666666</color>
+</resources>

--- a/ifttt-sdk-android/src/main/res/values/colors.xml
+++ b/ifttt-sdk-android/src/main/res/values/colors.xml
@@ -3,7 +3,7 @@
     <color name="ifttt_email_background_color">#EEEEEE</color>
     <color name="ifttt_email_hint_text_color">#CBCBCB</color>
     <color name="ifttt_progress_background_color">#414141</color>
-    <color name="ifttt_background_touch_color">#666666</color>
+    <color name="ifttt_background_touch_color">#444444</color>
     <color name="ifttt_progress_circle_color">#41FFFFFF</color>
     <color name="ifttt_about_button_color">#222222</color>
     <color name="ifttt_about_button_pressed_color">#666666</color>


### PR DESCRIPTION
One of our early adopters, Awair, supports Android 4.3.

We have agreed on a downgraded experience from the button that will redirect users to web to complete the authentication flow, as opposed to doing it in the SDK.