### PR TITLE
Add a border to the service icon if necessary

### DIFF
--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
@@ -279,7 +279,7 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
         progressTxt.setTypeface(boldTypeface);
 
         int checkMarkSize = getResources().getDimensionPixelSize(R.dimen.ifttt_check_mark_size);
-        int circleColor = ContextCompat.getColor(getContext(), R.color.ifttt_progress_circle_color);
+        int circleColor = ContextCompat.getColor(getContext(), R.color.ifttt_semi_transparent_white);
         int dotColor = Color.WHITE;
         CheckMarkDrawable drawable = new CheckMarkDrawable(checkMarkSize, circleColor, dotColor);
         completeImg = findViewById(R.id.ifttt_progress_check_mark);

--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/StartIconDrawable.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/StartIconDrawable.java
@@ -56,7 +56,7 @@ final class StartIconDrawable extends Drawable {
             startIcon.setColorFilter(Color.BLACK, PorterDuff.Mode.SRC_IN);
         }
 
-        borderColor = ContextCompat.getColor(context, R.color.ifttt_progress_circle_color);
+        borderColor = ContextCompat.getColor(context, R.color.ifttt_semi_transparent_white);
         borderWidth = context.getResources().getDimensionPixelSize(R.dimen.ifttt_button_border_width);
 
         this.startIcon.setAlpha(0);

--- a/ifttt-sdk-android/src/main/res/drawable/ifttt_button_border.xml
+++ b/ifttt-sdk-android/src/main/res/drawable/ifttt_button_border.xml
@@ -4,6 +4,6 @@
 
     <size android:height="@dimen/connect_button_height"/>
     <corners android:radius="@dimen/connect_button_radius"/>
-    <stroke android:color="@color/ifttt_progress_circle_color" android:width="@dimen/ifttt_button_border_width"/>
+    <stroke android:color="@color/ifttt_semi_transparent_white" android:width="@dimen/ifttt_button_border_width"/>
 
 </shape>

--- a/ifttt-sdk-android/src/main/res/values/colors.xml
+++ b/ifttt-sdk-android/src/main/res/values/colors.xml
@@ -4,7 +4,7 @@
     <color name="ifttt_email_hint_text_color">#CBCBCB</color>
     <color name="ifttt_progress_background_color">#414141</color>
     <color name="ifttt_background_touch_color">#444444</color>
-    <color name="ifttt_progress_circle_color">#41FFFFFF</color>
+    <color name="ifttt_semi_transparent_white">#41FFFFFF</color>
     <color name="ifttt_about_button_color">#222222</color>
     <color name="ifttt_about_button_pressed_color">#666666</color>
     <color name="ifttt_start_icon_background_on_dark">#FFFFFF</color>


### PR DESCRIPTION
If the service has a dark brand color, we want to add a border to the
service icon too, so that the toggle is still visible.