### PR TITLE
Use the primary service if there is only one

### DIFF
--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
@@ -1017,10 +1017,15 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
 
     private Service findWorksWithService(Connection connection) {
         Service otherService = null;
-        for (Service service : connection.services) {
-            if (!service.isPrimary) {
-                otherService = service;
-                break;
+        if (connection.services.size() == 1) {
+            // If there is only one service involved.
+            otherService = connection.services.get(0);
+        } else {
+            for (Service service : connection.services) {
+                if (!service.isPrimary) {
+                    otherService = service;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
There are Applets that use only one service, and we don't want to crash
the SDK for it. In practice this will be a very rare case, maybe even
invalid.