### PR TITLE
Enforce Connections to have same owner service

### DIFF
--- a/app/src/main/java/com/ifttt/api/demo/MainActivity.kt
+++ b/app/src/main/java/com/ifttt/api/demo/MainActivity.kt
@@ -20,6 +20,7 @@ import com.ifttt.ErrorResponse
 import com.ifttt.IftttApiClient
 import com.ifttt.api.PendingResult
 import com.ifttt.api.demo.api.ApiHelper
+import com.ifttt.api.demo.api.ApiHelper.SERVICE_ID
 import com.ifttt.ui.IftttConnectButton
 import com.squareup.picasso.Picasso
 
@@ -55,7 +56,7 @@ class MainActivity : AppCompatActivity() {
         iftttApiClient = IftttApiClient.Builder().setInviteCode(ApiHelper.INVITE_CODE).build()
         iftttConnectButton = findViewById<IftttConnectButton>(R.id.connect_button).apply {
             // Setup the Connect Button.
-            setup(EMAIL, iftttApiClient, ApiHelper.REDIRECT_URI) {
+            setup(EMAIL, SERVICE_ID, iftttApiClient, ApiHelper.REDIRECT_URI) {
                 // This is a required step to make sure the user doesn't have to connect your service on IFTTT
                 // during the Connection enable flow.
                 // The code here will be run on a background thread.

--- a/app/src/main/java/com/ifttt/api/demo/api/ApiHelper.kt
+++ b/app/src/main/java/com/ifttt/api/demo/api/ApiHelper.kt
@@ -16,6 +16,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 object ApiHelper {
     const val INVITE_CODE = "21790-7d53f29b1eaca0bdc5bd6ad24b8f4e1c"
     const val REDIRECT_URI = "ifttt-api-example://sdk-callback"
+    const val SERVICE_ID = "ifttt_api_example"
 
     private val exampleAppTokenInterceptor = ExampleAppTokenInterceptor()
     private val okHttpClient = OkHttpClient.Builder()

--- a/ifttt-sdk-android/src/test/java/com/ifttt/IftttConnectButtonTest.java
+++ b/ifttt-sdk-android/src/test/java/com/ifttt/IftttConnectButtonTest.java
@@ -22,7 +22,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
 import static com.google.common.truth.Truth.assertThat;
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.fail;
 
 @RunWith(RobolectricTestRunner.class)
 public final class IftttConnectButtonTest {
@@ -77,7 +77,7 @@ public final class IftttConnectButtonTest {
         JsonReader jsonReader = JsonReader.of(Okio.buffer(Okio.source(inputStream)));
         Connection connection = adapter.fromJson(jsonReader);
 
-        button.setup("a@b.com", new IftttApiClient.Builder().build(), "", () -> "");
+        button.setup("a@b.com", "instagram", new IftttApiClient.Builder().build(), "", () -> "");
         button.setConnection(connection);
 
         TextView connectText = button.findViewById(R.id.connect_with_ifttt);
@@ -85,5 +85,17 @@ public final class IftttConnectButtonTest {
 
         TextSwitcher helperText = button.findViewById(R.id.ifttt_helper_text);
         assertThat(helperText.getCurrentView()).isInstanceOf(TextView.class);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testOwnerServiceCheck() throws IOException {
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream("connection.json");
+        JsonReader jsonReader = JsonReader.of(Okio.buffer(Okio.source(inputStream)));
+        Connection connection = adapter.fromJson(jsonReader);
+
+        button.setup("a@b.com", "not_owner_service", new IftttApiClient.Builder().build(), "", () -> "");
+        button.setConnection(connection);
+
+        fail();
     }
 }


### PR DESCRIPTION
This is to prevent clients to embed Connections that they don't own. The
flow is not designed for such use case.