### PR TITLE
Enable dragging in initial state

### DIFF
--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
@@ -500,8 +500,7 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
         } else {
             recordState(Enabled);
 
-            String enabledText = getResources().getString(R.string.ifttt_connected);
-            setConnectStateText(connectStateTxt, enabledText, enabledText);
+            connectStateTxt.setText(getResources().getString(R.string.ifttt_connected));
 
             helperTxt.setOnClickListener(new DebouncingOnClickListener() {
                 @Override


### PR DESCRIPTION
The email field animation will not start until the user releases the
knob. The animation now becomes the knob travels from current `left` to
the end of the button width, with the velocity of either 0 or x velocity
of the dragging gesture. The rest of the animtion is unchanged.