### PR TITLE
Fix connect state text after disconnecting

### DIFF
--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
@@ -487,7 +487,8 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
 
             setConnectStateText(connectStateTxt,
                     getResources().getString(R.string.ifttt_connect_to, worksWithService.name),
-                    getResources().getString(R.string.ifttt_connect));
+                    getResources().getString(R.string.ifttt_connect),
+                    text -> iconDragHelperCallback.setTexts("", text));
 
             helperTxt.setOnClickListener(new DebouncingOnClickListener() {
                 @Override
@@ -495,12 +496,12 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
                     getContext().startActivity(IftttAboutActivity.intent(context, connection));
                 }
             });
-
-            iconDragHelperCallback.setTexts("", connectStateTxt.getText());
         } else {
             recordState(Enabled);
 
             connectStateTxt.setText(getResources().getString(R.string.ifttt_connected));
+            iconDragHelperCallback.setTexts(getResources().getText(R.string.ifttt_connected),
+                    getResources().getText(R.string.ifttt_connection_off));
 
             helperTxt.setOnClickListener(new DebouncingOnClickListener() {
                 @Override
@@ -508,9 +509,6 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
                     buttonApiHelper.redirectToPlayStore(context);
                 }
             });
-
-            iconDragHelperCallback.setTexts(getResources().getText(R.string.ifttt_connected),
-                    getResources().getText(R.string.ifttt_connection_off));
         }
 
         // Set a placeholder for the image.


### PR DESCRIPTION
We will need to potentially wait for the layout measurement before we
know what text to use for initial state, because `text` can be too long,
 in which case we will use `fallback`.