### PR TITLE
Use lifecycle-aware animator listeners

### DIFF
--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/ButtonApiHelper.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/ButtonApiHelper.java
@@ -51,7 +51,7 @@ final class ButtonApiHelper {
         oAuthCodeProvider = provider;
     }
 
-    void disableConnection(String id, ResultCallback<Connection> resultCallback) {
+    void disableConnection(Lifecycle lifecycle, String id, ResultCallback<Connection> resultCallback) {
         PendingResult<Connection> pendingResult = iftttApi.disableConnection(id);
         lifecycle.addObserver(new PendingResultLifecycleObserver<>(pendingResult));
         pendingResult.execute(new ResultCallback<Connection>() {
@@ -65,6 +65,8 @@ final class ButtonApiHelper {
                 resultCallback.onFailure(errorResponse);
             }
         });
+
+        lifecycle.addObserver(new PendingResultLifecycleObserver<>(pendingResult));
     }
 
     void redirectToWeb(Context context, Connection connection, String email, ButtonState buttonState) {

--- a/ifttt-sdk-android/src/main/res/layout/view_ifttt_connect.xml
+++ b/ifttt-sdk-android/src/main/res/layout/view_ifttt_connect.xml
@@ -98,7 +98,6 @@
         android:id="@+id/ifttt_helper_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="16dp"
-        android:background="?selectableItemBackground"/>
+        android:padding="16dp"/>
 
 </merge>


### PR DESCRIPTION
Because at the end of some animations, we are going to open web view, it
is important that the animators know when the host Activity has been
stopped, so that it won't open up WebView even after the animations
are canceled, or the Activity is no longer on the foreground.