### PR TITLE
Continue render ui when user token is not present

### DIFF
--- a/app/src/main/java/com/ifttt/api/demo/MainActivity.kt
+++ b/app/src/main/java/com/ifttt/api/demo/MainActivity.kt
@@ -47,7 +47,7 @@ class MainActivity : AppCompatActivity() {
 
         override fun onFailure(code: String?) {
             if (code == "unauthorized") {
-                showSnackbar(getString(R.string.user_auth_error))
+                renderUi()
             } else {
                 showSnackbar(getString(R.string.network_request_error))
             }


### PR DESCRIPTION
This happens when the account is new, or the user has not yet connected
Grocery Express before.