### PR TITLE
Use a custom view to wrap ViewDragHelper

### DIFF
--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/DragParentView.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/DragParentView.java
@@ -1,0 +1,57 @@
+package com.ifttt.ui;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.widget.FrameLayout;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.customview.widget.ViewDragHelper;
+import javax.annotation.CheckReturnValue;
+
+/**
+ * Custom view used to handle dragging gesture with a {@link ViewDragHelper}.
+ */
+final class DragParentView extends FrameLayout {
+
+    private ViewDragHelper helper;
+
+    public DragParentView(@NonNull Context context) {
+        super(context);
+    }
+
+    public DragParentView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public DragParentView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @CheckReturnValue
+    ViewDragHelper getViewDragHelperCallback(ViewDragHelper.Callback callback) {
+        helper = ViewDragHelper.create(this, callback);
+        return helper;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        if (helper == null) {
+            throw new IllegalStateException("Call getViewDragHelperCallback first.");
+        }
+
+        if (helper.shouldInterceptTouchEvent(ev)) {
+            return true;
+        }
+        return super.onInterceptTouchEvent(ev);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (helper == null) {
+            throw new IllegalStateException("Call getViewDragHelperCallback first.");
+        }
+        helper.processTouchEvent(event);
+        return super.onTouchEvent(event);
+    }
+}

--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/IftttConnectButton.java
@@ -22,7 +22,6 @@ import android.text.SpannableString;
 import android.text.Spanned;
 import android.util.AttributeSet;
 import android.view.Gravity;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.view.animation.LinearInterpolator;
@@ -132,7 +131,7 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
     private final TextSwitcher connectStateTxt;
     private final ImageView iconImg;
     private final TextSwitcher helperTxt;
-    private final FrameLayout buttonRoot;
+    private final DragParentView buttonRoot;
 
     private final int iconSize;
 
@@ -201,7 +200,7 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
                 Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 
         iconDragHelperCallback = new IconDragHelperCallback();
-        viewDragHelper = ViewDragHelper.create(buttonRoot, iconDragHelperCallback);
+        viewDragHelper = buttonRoot.getViewDragHelperCallback(iconDragHelperCallback);
     }
 
     @Override
@@ -214,21 +213,6 @@ public final class IftttConnectButton extends LinearLayout implements LifecycleO
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         lifecycleRegistry.markState(DESTROYED);
-    }
-
-    @Override
-    public boolean onInterceptTouchEvent(MotionEvent ev) {
-        if (viewDragHelper.shouldInterceptTouchEvent(ev)) {
-            return true;
-        }
-
-        return super.onInterceptTouchEvent(ev);
-    }
-
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        viewDragHelper.processTouchEvent(event);
-        return super.onTouchEvent(event);
     }
 
     @Override

--- a/ifttt-sdk-android/src/main/java/com/ifttt/ui/StartIconDrawable.java
+++ b/ifttt-sdk-android/src/main/java/com/ifttt/ui/StartIconDrawable.java
@@ -236,26 +236,39 @@ final class StartIconDrawable extends Drawable {
                 }
 
                 StartIconDrawable drawable = (StartIconDrawable) view.getBackground();
-                if (event.getAction() == MotionEvent.ACTION_DOWN) {
-                    ongoingAnimator = drawable.getPressedAnimator(true);
-                    ongoingAnimator.start();
-                    return true;
-                } else if (event.getAction() == MotionEvent.ACTION_UP
-                        || event.getAction() == MotionEvent.ACTION_CANCEL) {
-                    if (ongoingAnimator == null) {
+                switch (event.getAction()) {
+                    case MotionEvent.ACTION_DOWN:
+                        ongoingAnimator = drawable.getPressedAnimator(true);
+                        ongoingAnimator.start();
                         return true;
-                    }
+                    case MotionEvent.ACTION_UP:
+                        // Fall through
+                    case MotionEvent.ACTION_CANCEL:
+                        if (ongoingAnimator == null) {
+                            return true;
+                        }
 
-                    ongoingAnimator.cancel();
-                    drawable.getPressedAnimator(false).start();
-                    ongoingAnimator = null;
+                        ongoingAnimator.cancel();
+                        drawable.getPressedAnimator(false).start();
+                        ongoingAnimator = null;
 
-                    if (event.getAction() == MotionEvent.ACTION_UP) {
-                        v.performClick();
-                    }
-                    return true;
+                        if (event.getAction() == MotionEvent.ACTION_UP) {
+                            v.performClick();
+                        }
+                        return true;
+                    case MotionEvent.ACTION_MOVE:
+                        // Revert the animation and dismiss click.
+                        if (ongoingAnimator == null) {
+                            return true;
+                        }
+
+                        ongoingAnimator.cancel();
+                        drawable.getPressedAnimator(false).start();
+                        ongoingAnimator = null;
+                        return true;
+                    default:
+                        return false;
                 }
-                return false;
             }
         });
     }

--- a/ifttt-sdk-android/src/main/res/layout/view_ifttt_connect.xml
+++ b/ifttt-sdk-android/src/main/res/layout/view_ifttt_connect.xml
@@ -2,13 +2,11 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <FrameLayout
+    <com.ifttt.ui.DragParentView
         android:id="@+id/ifttt_button_root"
         android:layout_width="@dimen/ifttt_connect_button_width"
         android:layout_height="@dimen/connect_button_height"
         android:layout_marginTop="@dimen/ifttt_space_med"
-        android:clipChildren="false"
-        android:clipToPadding="false"
         android:alpha="0">
 
         <EditText
@@ -69,7 +67,7 @@
             android:elevation="@dimen/ifttt_icon_elevation"
             android:scaleType="centerInside"/>
 
-    </FrameLayout>
+    </com.ifttt.ui.DragParentView>
 
     <TextSwitcher
         android:id="@+id/ifttt_helper_text"


### PR DESCRIPTION
Because the `iconImg` view is not a direct child of `IftttConnectButton`, processing touch events directly in the button view causes the view bound to not match, and hence some touch events are ignored.

I don't know if there is better ways to use ViewDragHelper without wrapping it with a custom view, but having a custom view to host the toggle ImageView fixes the issue.