### PR TITLE
Always allow helper text to be clickable after setting connection

### DIFF
--- a/connect-button/src/main/java/com/ifttt/ui/BaseConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/ui/BaseConnectButton.java
@@ -436,9 +436,6 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
                 iconDragHelperCallback.setTrackEndColor(trackEndColor);
             }
 
-            helperTxt.setOnClickListener(
-                    v -> getContext().startActivity(AboutIftttActivity.intent(getContext(), connection)));
-
             OnClickListener onClickListener = v -> {
                 buttonRoot.setOnClickListener(null);
                 iconImg.setOnClickListener(null);
@@ -477,6 +474,9 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
         }
 
         StartIconDrawable.setPressListener(iconImg);
+
+        helperTxt.setOnClickListener(
+                v -> getContext().startActivity(AboutIftttActivity.intent(getContext(), connection)));
     }
 
     private void setServiceIconImage(@Nullable Bitmap bitmap) {


### PR DESCRIPTION
Currently the logic is wrong: the helper text is not clickable if the Connection is enabled when we set it.