### PR TITLE
Add javadoc comments for cover image fields

### DIFF
--- a/connect-button/src/main/java/com/ifttt/CoverImage.java
+++ b/connect-button/src/main/java/com/ifttt/CoverImage.java
@@ -8,11 +8,34 @@ import com.squareup.moshi.Json;
  * Cover image data structure for a Connection, including image URLs for different dimensions.
  */
 public final class CoverImage implements Parcelable {
+    /**
+     * URL String for cover image in 480x240.
+     */
     @Json(name = "480w_url") final String imageUrl480w;
+
+    /**
+     * URL String for cover image in 720x360.
+     */
     @Json(name = "720w_url") final String imageUrl720w;
+
+    /**
+     * URL String for cover image in 1080x540.
+     */
     @Json(name = "1080w_url") final String imageUrl1080w;
+
+    /**
+     * URL String for cover image in 1440x720.
+     */
     @Json(name = "1440w_url") final String imageUrl1440w;
+
+    /**
+     * URL String for cover image in 2880x1440.
+     */
     @Json(name = "2880w_url") final String imageUrl2880w;
+
+    /**
+     * URL String for cover image in 4320x2160.
+     */
     @Json(name = "4320w_url") final String imageUrl4320w;
 
     public CoverImage(String imageUrl480w, String imageUrl720w, String imageUrl1080w, String imageUrl1440w,


### PR DESCRIPTION
To better explain the dimension of these images.