### PR TITLE
Switch back to setClickable for helper text

### DIFF
--- a/connect-button/src/main/java/com/ifttt/ui/BaseConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/ui/BaseConnectButton.java
@@ -235,7 +235,7 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
             listener.onClick(v);
 
             // Revert back to the original text.
-            helperTxt.setOnClickListener(null);
+            helperTxt.setClickable(false);
             helperTxt.showNext();
             helperTxt.getNextView().setAlpha(currentAlpha);
         });
@@ -771,8 +771,7 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
                     public void revert() {
                         helperTxt.showNext();
                         helperTxt.getNextView().setAlpha(currentAlpha);
-                        helperTxt.setOnClickListener(
-                                v -> getContext().startActivity(AboutIftttActivity.intent(getContext(), connection)));
+                        helperTxt.setClickable(true);
                     }
 
                     @Override
@@ -784,7 +783,7 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
                                 0, errorMessage.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                         helperTxt.setText(errorMessage);
                         helperTxt.getCurrentView().setAlpha(1f);
-                        helperTxt.setOnClickListener(null);
+                        helperTxt.setClickable(false);
                     }
                 };
 
@@ -802,7 +801,7 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
             emailValidation.start();
             String email = emailEdt.getText().toString();
             buttonApiHelper.prepareAuthentication(email);
-            helperTxt.setOnClickListener(null);
+            helperTxt.setClickable(false);
         };
 
         // Only enable the OnClickListener after the animation has completed.
@@ -832,6 +831,8 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
                     }
                     return false;
                 });
+
+                helperTxt.setClickable(true);
             }
         });
 
@@ -861,7 +862,7 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
             public void onAnimationStart(Animator animation) {
                 super.onAnimationStart(animation);
                 helperTxt.setText(worksWithIfttt);
-                helperTxt.setOnClickListener(null);
+                helperTxt.setClickable(false);
             }
 
             @Override


### PR DESCRIPTION
In a previous PR, we switched to setting the OnClickListener on both the helper text and the main button to avoid the view being able to be clicked when it should not be. The problem that we are having since then is that toggling helper text's clickable attribute became unnecessarily complex. When the helper text is clickable, it always goes to the about page.

Switching back to using setClickable to control whether the helper text is clickable, and only set the on click listener once.

https://ifttt-dev.atlassian.net/browse/MOB-838