### PR TITLE
Remove fetching user token API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-beta01'
+        classpath 'com.android.tools.build:gradle:3.5.0-beta04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'

--- a/connect-button/src/main/java/com/ifttt/ConnectionApiClient.java
+++ b/connect-button/src/main/java/com/ifttt/ConnectionApiClient.java
@@ -143,11 +143,5 @@ public final class ConnectionApiClient {
         public PendingResult<User> user() {
             return new ApiPendingResult<>(retrofitConnectionApi.user(), errorResponseJsonAdapter);
         }
-
-        @Override
-        public PendingResult<String> userToken(String oAuthToken, String userId, String serviceKey) {
-            return new ApiPendingResult<>(retrofitConnectionApi.getUserToken(oAuthToken, userId, serviceKey),
-                    errorResponseJsonAdapter);
-        }
     }
 }

--- a/connect-button/src/main/java/com/ifttt/RetrofitConnectionApi.java
+++ b/connect-button/src/main/java/com/ifttt/RetrofitConnectionApi.java
@@ -1,13 +1,9 @@
 package com.ifttt;
 
-import com.ifttt.UserTokenJsonAdapter.UserTokenRequest;
 import retrofit2.Call;
-import retrofit2.http.Body;
 import retrofit2.http.GET;
-import retrofit2.http.Header;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
-import retrofit2.http.Query;
 
 /**
  * Connection API endpoints.
@@ -22,8 +18,4 @@ interface RetrofitConnectionApi {
 
     @GET("/v2/me")
     Call<User> user();
-
-    @POST("/v2/user_token")
-    Call<String> getUserToken(@UserTokenRequest @Body String token, @Query("user_id") String userId,
-            @Header("IFTTT-Service-Key") String serviceKey);
 }

--- a/connect-button/src/main/java/com/ifttt/api/ConnectionApi.java
+++ b/connect-button/src/main/java/com/ifttt/api/ConnectionApi.java
@@ -35,16 +35,4 @@ public interface ConnectionApi {
      * @return A {@link PendingResult} for the API call execution.
      */
     PendingResult<User> user();
-
-    /**
-     * API for exchanging an IFTTT user token. The IFTTT user token may be used to make user authenticated API calls,
-     * for example {@link #disableConnection(String)}.
-     *
-     * @param oAuthToken Your user's OAuth access token.
-     * @param serviceKey Your IFTTT service key.
-     * @param userId User's id in your service.
-     *
-     * @return A {@link PendingResult} for the API call execution.
-     */
-    PendingResult<String> userToken(String oAuthToken, String userId, String serviceKey);
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 08 13:13:11 PDT 2019
+#Wed Jun 05 14:08:00 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Encourage developers to get user token via their own endpoint, instead of potentially hardcoding the service key in the app.