### PR TITLE
Remove ColorFilter when press state animation ends

### DIFF
--- a/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
@@ -560,12 +560,8 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
             @Override
             public void onAnimationUpdate(ValueAnimator animation) {
                 super.onAnimationUpdate(animation);
-
                 ViewCompat.offsetLeftAndRight(checkMarkView,
                         ((Integer) animation.getAnimatedValue()) - checkMarkView.getLeft());
-                int color =
-                        (int) EVALUATOR.evaluate(animation.getAnimatedFraction(), BLACK, worksWithService.brandColor);
-                ((StartIconDrawable) iconImg.getBackground()).setBackgroundColor(color);
             }
         });
 

--- a/connect-button/src/main/java/com/ifttt/connect/ui/StartIconDrawable.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/StartIconDrawable.java
@@ -1,6 +1,7 @@
 package com.ifttt.connect.ui;
 
 import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.animation.ArgbEvaluator;
 import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
@@ -196,6 +197,15 @@ final class StartIconDrawable extends Drawable {
                             (Integer) EVALUATOR.evaluate((Float) animation.getAnimatedValue(), originalColor,
                                     darkerColor), PorterDuff.Mode.SRC_IN));
             invalidateSelf();
+        });
+        pressAnimator.addListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                if (!pressed) {
+                    // If not pressed, at the end of the animation, remove the ColorFilter.
+                    background.setColorFilter(null);
+                }
+            }
         });
         return pressAnimator;
     }


### PR DESCRIPTION
Currently we do not clear the ColorFilter after the press state animator ends when the button is no longer pressed, which causes the knob to continue shwoing the previous press color even if we call `setBackgroundColor`.