### PR TITLE
Add back Retrofit, Moshi and OkHttp dependencies for demo app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,10 @@ android {
 
 dependencies {
     implementation "com.ifttt:connect-button:2.0.0"
+    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
+    implementation "com.squareup.moshi:moshi:$moshiVersion"
+    implementation "com.squareup.moshi:moshi-adapters:$moshiVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okHttpVersion"
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'com.squareup.picasso:picasso:2.71828'


### PR DESCRIPTION
There was an issue in the intiial commit that removed some of the dependencies that were previously transitive dependencies for the SDK.

Adding them back as we still need them in the demo app.