### PR TITLE
Add try-catch for CredentialProvider calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
@@ -148,7 +148,7 @@ final class ButtonApiHelper {
         RedirectPrepAsyncTask task = new RedirectPrepAsyncTask(credentialsProvider,
                 connectionApiClient.isUserAuthenticated() ? connectionApiClient.api().user() : null, email,
                 prepResult -> {
-                    this.oAuthCode = prepResult.opaqueToken;
+                    this.oAuthCode = prepResult.oauthToken;
                     this.accountFound = prepResult.accountFound;
                     this.userLogin = prepResult.userLogin;
                 });

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButton.java
@@ -27,6 +27,7 @@ import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LifecycleRegistry;
 import androidx.lifecycle.OnLifecycleEvent;
+import com.ifttt.connect.BuildConfig;
 import com.ifttt.connect.Connection;
 import com.ifttt.connect.ConnectionApiClient;
 import com.ifttt.connect.ErrorResponse;
@@ -446,7 +447,7 @@ public class ConnectButton extends FrameLayout implements LifecycleOwner {
     private static final class UserTokenAsyncTask extends android.os.AsyncTask<Void, Void, String> {
 
         private interface UserTokenCallback {
-            void onUserTokenSet();
+            void onComplete();
         }
 
         private final CredentialsProvider callback;
@@ -459,13 +460,24 @@ public class ConnectButton extends FrameLayout implements LifecycleOwner {
 
         @Override
         protected String doInBackground(Void... voids) {
-            return callback.getUserToken();
+            try {
+                return callback.getUserToken();
+            } catch (Exception e) {
+                if (BuildConfig.DEBUG) {
+                    e.printStackTrace();
+                }
+
+                return null;
+            }
         }
 
         @Override
-        protected void onPostExecute(String s) {
-            API_CLIENT.setUserToken(s);
-            userTokenCallback.onUserTokenSet();
+        protected void onPostExecute(@Nullable String s) {
+            if (s != null) {
+                API_CLIENT.setUserToken(s);
+            }
+
+            userTokenCallback.onComplete();
         }
     }
 


### PR DESCRIPTION
One thing that we need to double check is whether the CredentialProvider's methods implementation won't affect other components of the SDK.

To do that, I'm adding try-catch on the callsite, and proceed with null values if exceptions happen.