### PR TITLE
Add re-connect functionality to ConnectButton

### DIFF
--- a/connect-button/src/main/java/com/ifttt/connect/ConnectionApiClient.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ConnectionApiClient.java
@@ -140,6 +140,11 @@ public final class ConnectionApiClient {
         }
 
         @Override
+        public PendingResult<Connection> reenableConnection(String id) {
+            return new ApiPendingResult<>(retrofitConnectionApi.reenableConnection(id), errorResponseJsonAdapter);
+        }
+
+        @Override
         public PendingResult<User> user() {
             return new ApiPendingResult<>(retrofitConnectionApi.user(), errorResponseJsonAdapter);
         }

--- a/connect-button/src/main/java/com/ifttt/connect/RetrofitConnectionApi.java
+++ b/connect-button/src/main/java/com/ifttt/connect/RetrofitConnectionApi.java
@@ -16,6 +16,9 @@ interface RetrofitConnectionApi {
     @POST("/v2/connections/{id}/disable")
     Call<Connection> disableConnection(@Path("id") String id);
 
+    @POST("/v2/connections/{id}/enable")
+    Call<Connection> reenableConnection(@Path("id") String id);
+
     @GET("/v2/me")
     Call<User> user();
 }

--- a/connect-button/src/main/java/com/ifttt/connect/api/ConnectionApi.java
+++ b/connect-button/src/main/java/com/ifttt/connect/api/ConnectionApi.java
@@ -29,6 +29,14 @@ public interface ConnectionApi {
     PendingResult<Connection> disableConnection(String id);
 
     /**
+     * API for re-enable a Connection
+     *
+     * @param id  Connection id.
+     * @return A {@link PendingResult} for the API call execution.
+     */
+    PendingResult<Connection> reenableConnection(String id);
+
+    /**
      * API for retrieving information about the IFTTT user, as well as the authentication level of the current
      * ConnectionApiClient.
      *

--- a/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
@@ -495,6 +495,10 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
                         @Override
                         public void onAnimationStart(Animator animation) {
                             super.onAnimationStart(animation);
+                            if (isCanceled()) {
+                                return;
+                            }
+
                             buttonApiHelper.reenableConnection(getLifecycle(), connection.id,
                                     new PendingResult.ResultCallback<Connection>() {
                                         @Override
@@ -608,6 +612,10 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
             @Override
             public void onAnimationStart(Animator animation) {
                 super.onAnimationStart(animation);
+                if (isCanceled()) {
+                    return;
+                }
+
                 currentProgress.setProgressText(null);
             }
         });
@@ -616,6 +624,9 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
             @Override
             public void onAnimationStart(Animator animation) {
                 super.onAnimationStart(animation);
+                if (isCanceled()) {
+                    return;
+                }
 
                 buttonRoot.setBackground(buildButtonBackground(getContext(), BLACK));
                 connectStateTxt.setAlpha(1f);
@@ -653,6 +664,9 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
             @Override
             public void onAnimationStart(Animator animation) {
                 super.onAnimationStart(animation);
+                if (isCanceled()) {
+                    return;
+                }
 
                 // Remove icon elevation when the progress bar is visible.
                 ViewCompat.setElevation(iconImg, 0f);

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
@@ -43,7 +43,7 @@ final class ButtonApiHelper {
     @Nullable private String oAuthCode;
     @Nullable private String userLogin;
 
-    // Default to account existed, so that we don't addTo unnecessary account through the automatic flow. This is used
+    // Default to account existed, so that we don't create unnecessary account through the automatic flow. This is used
     // to help simplify the flow by setting an aggressive timeout for account checking requests.
     private boolean accountFound = true;
 

--- a/connect-button/src/main/java/com/ifttt/connect/ui/CheckMarkView.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/CheckMarkView.java
@@ -51,10 +51,10 @@ final class CheckMarkView extends AppCompatImageView {
         int height = parent.getResources().getDimensionPixelSize(R.dimen.ifttt_check_mark_height);
         FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(width, height);
         lp.gravity = Gravity.CENTER;
+        checkMarkView.setLayoutParams(lp);
 
         ViewCompat.setElevation(checkMarkView, parent.getResources().getDimension(R.dimen.ifttt_icon_elevation));
 
-        parent.addView(checkMarkView, lp);
         return checkMarkView;
     }
 }

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButtonState.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButtonState.java
@@ -8,8 +8,8 @@ public enum ConnectButtonState {
     Initial,
 
     /**
-     * A button state for the create account authentication step. In this step, the user is going to be redirected
-     * to web to create an account and continue with service connection.
+     * A button state for the addTo account authentication step. In this step, the user is going to be redirected
+     * to web to addTo an account and continue with service connection.
      */
     CreateAccount,
 

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButtonState.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButtonState.java
@@ -8,8 +8,8 @@ public enum ConnectButtonState {
     Initial,
 
     /**
-     * A button state for the addTo account authentication step. In this step, the user is going to be redirected
-     * to web to addTo an account and continue with service connection.
+     * A button state for the create account authentication step. In this step, the user is going to be redirected
+     * to web to create an account and continue with service connection.
      */
     CreateAccount,
 

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ProgressView.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ProgressView.java
@@ -78,7 +78,7 @@ final class ProgressView extends FrameLayout {
         textSwitcher.setText(text);
     }
 
-    static ProgressView create(ViewGroup parent, @ColorInt int primaryColor, @ColorInt int progressColor) {
+    static ProgressView addTo(ViewGroup parent, @ColorInt int primaryColor, @ColorInt int progressColor) {
         ProgressView progressView = new ProgressView(parent.getContext());
         FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT);
         progressView.setLayoutParams(lp);


### PR DESCRIPTION
Adding the ability for users to re-connect an existing Connection via the ConnectButton, without having to go through the connect flow (including potential configuration step) again.

This PR includes
* visual changes to the re-connect flow: adding a simple progress animation for re-connect scenario
* adding an API from Connect API to re-connect an existing connection