### PR TITLE
Connect Button resume state fixes

### DIFF
--- a/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
@@ -321,12 +321,16 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
      *
      * @param result Authentication flow redirect result from the web view.
      */
-    void setConnectResult(ConnectResult result) {
+    void setConnectResult(@Nullable ConnectResult result) {
         if (activityLifecycleCallbacks != null) {
             // Unregister existing ActivityLifecycleCallbacks and let the AuthenticationResult handle the button
             // state change.
             ((Activity) getContext()).getApplication().unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks);
             activityLifecycleCallbacks = null;
+        }
+
+        if (result == null) {
+            return;
         }
 
         cleanUpViews(ProgressView.class);
@@ -499,6 +503,9 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
                                 return;
                             }
 
+                            // Remove icon elevation when the progress bar is visible.
+                            ViewCompat.setElevation(iconImg, 0f);
+
                             buttonApiHelper.reenableConnection(getLifecycle(), connection.id,
                                     new PendingResult.ResultCallback<Connection>() {
                                         @Override
@@ -628,7 +635,15 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
                     return;
                 }
 
+                // Reset email UI.
+                emailEdt.setVisibility(GONE);
+                ((StartIconDrawable) iconImg.getBackground()).reset();
+                ((StartIconDrawable) iconImg.getBackground()).setBackgroundColor(worksWithService.brandColor);
+
+                // Reset Button background.
                 buttonRoot.setBackground(buildButtonBackground(getContext(), BLACK));
+
+                // Reset Button text.
                 connectStateTxt.setAlpha(1f);
                 connectStateTxt.setText(getResources().getString(R.string.ifttt_connected));
                 adjustTextViewLayout(connectStateTxt, Enabled);

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ConnectResult.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ConnectResult.java
@@ -84,10 +84,11 @@ public final class ConnectResult implements Parcelable {
      * @param intent Intent object that should come from your deep link handler Activity.
      * @return An instance of ConnectResult that can be used in setting up {@link BaseConnectButton}.
      */
+    @Nullable
     public static ConnectResult fromIntent(Intent intent) {
         Uri data = intent.getData();
         if (data == null) {
-            return UNKNOWN;
+            return null;
         }
 
         String nextStepParam = data.getQueryParameter("next_step");


### PR DESCRIPTION
#### Make ConnectResult nullable from the `ConnectResult.fromIntent()` method
We actually need it to be nullable to represent cases where onNewIntent is called from non-redirect. In this case, we should not try to force the ConnectButton to be in either initial state or the email state.
#### Reset knob background when running complete animation
To account for an issue caused by redirecting to Gmail: the app is temporarily moved back to foreground, and onResume is going to be called. With the ActivityLifecycleCallbacks registered, the onActivityOnResume is going to be called, and we are going to try to restore the button state, which is incorrect.

Adding an extra reset knob background step to account for this.