### PR TITLE
Reset ConnectionApiClient's authorization when logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ The APIs available are:
 * `user`: return the authenticated user.
 * `userToken`: given the user's OAuth token to your service, plus your IFTTT Service key, return the IFTTT user token.
 
-**Note:** When setting up a ConnectButton, if there is no ConnectionApiClient instance provided by the Configuration, a default one will be used.
+**Note:** When setting up a ConnectButton, if there is no ConnectionApiClient instance provided by the Configuration, a default one will be used. If your app manages user login, you should consider using your own ConnectApiClient instance, so that you can control the lifecycle of the authorization and tie it to the logged in user. 
 
 ### Authentication with IftttApiClient
 

--- a/app/src/main/java/com/ifttt/groceryexpress/MainActivity.kt
+++ b/app/src/main/java/com/ifttt/groceryexpress/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.google.android.material.textfield.TextInputLayout
+import com.ifttt.connect.ConnectionApiClient
 import com.ifttt.connect.ui.ConnectButton
 import com.ifttt.connect.ui.ConnectResult
 import com.ifttt.connect.ui.CredentialsProvider
@@ -121,7 +122,9 @@ class MainActivity : AppCompatActivity() {
                     , REDIRECT_URI
                 ).setOnFetchCompleteListener { connection ->
                     findViewById<TextView>(R.id.connection_title).text = connection.name
-                }.build()
+                }
+                    .setConnectionApiClient(ConnectionApiClient.Builder(this).build()) // Provide a new ConnectionApiClient to reset the authorization header.
+                    .build()
                 connectButton.setup(configuration)
             }
             .show()

--- a/connect-button/src/main/java/com/ifttt/connect/ConnectionApiClient.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ConnectionApiClient.java
@@ -58,7 +58,7 @@ public final class ConnectionApiClient {
      */
     @MainThread
     @CheckReturnValue
-    public boolean isUserAuthenticated() {
+    public boolean isUserAuthorized() {
         return tokenInterceptor.isUserAuthenticated();
     }
 

--- a/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
@@ -62,6 +62,7 @@ import static android.graphics.Color.WHITE;
 import static androidx.lifecycle.Lifecycle.State.CREATED;
 import static androidx.lifecycle.Lifecycle.State.DESTROYED;
 import static androidx.lifecycle.Lifecycle.State.STARTED;
+import static com.ifttt.connect.Connection.Status.disabled;
 import static com.ifttt.connect.Connection.Status.enabled;
 import static com.ifttt.connect.Connection.Status.never_enabled;
 import static com.ifttt.connect.Connection.Status.unknown;
@@ -477,7 +478,8 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
                 // Cancel potential disable connection API call.
                 buttonApiHelper.cancelDisconnect();
 
-                if (connection.status == never_enabled || connection.status == unknown) {
+                if (connection.status == never_enabled || connection.status == unknown || (connection.status == disabled
+                        && !buttonApiHelper.isUserAuthorized())) {
                     if (buttonApiHelper.shouldPresentEmail(getContext())) {
                         buildEmailTransitionAnimator(0).start();
                     } else {

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
@@ -120,7 +120,17 @@ final class ButtonApiHelper {
             return false;
         }
 
-        return !connectionApiClient.isUserAuthenticated();
+        return !connectionApiClient.isUserAuthorized();
+    }
+
+    @CheckReturnValue
+    boolean shouldPresentCreateAccount(Context context) {
+        return shouldPresentEmail(context) && !accountFound;
+    }
+
+    @CheckReturnValue
+    boolean isUserAuthorized() {
+        return connectionApiClient.isUserAuthorized();
     }
 
     void connect(Context context, Connection connection, String email, ConnectButtonState buttonState) {
@@ -162,14 +172,10 @@ final class ButtonApiHelper {
         return launchIntent;
     }
 
-    boolean shouldPresentCreateAccount(Context context) {
-        return shouldPresentEmail(context) && !accountFound;
-    }
-
     @MainThread
     void prepareAuthentication(String email) {
         RedirectPrepAsyncTask task = new RedirectPrepAsyncTask(credentialsProvider,
-                connectionApiClient.isUserAuthenticated() ? connectionApiClient.api().user() : null, email,
+                connectionApiClient.isUserAuthorized() ? connectionApiClient.api().user() : null, email,
                 prepResult -> {
                     this.oAuthCode = prepResult.oauthToken;
                     this.accountFound = prepResult.accountFound;


### PR DESCRIPTION
This is to demonstrate how we control the authorization for the API calls within ConnectButton, as well as fixing an issue in Grocery Express that the auth header is not cleared when users log out.