### PR TITLE
Remove disableConnection from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,6 @@ ConnectionApi api = apiClient.api();
 
 The APIs available are:
 * `showConnection`: returns metadata for a Connection.
-* `disableConnection`: disable a Connection. User authentication level required.
 * `user`: return the authenticated user.
 * `userToken`: given the user's OAuth token to your service, plus your IFTTT Service key, return the IFTTT user token.
 
@@ -269,4 +268,3 @@ connectionApiClient.setUserToken(userToken);
 
 After that, subsequent API calls will be user-authenticated:
 * `ConnectionApi#showConnection` will return Connection status for the user, whether it is `never_enabled`, `enabled` or `disabled`.
-* `ConnectionApi#disableConnection` can be used to disable a Connection. 


### PR DESCRIPTION
We’re going to remove the documentation referring to the `disableConnection` endpoint in the Android SDK since it’s not documented elsewhere, and it’s not a flow we want to encourage.

Instead of considering a connection having a 1:1 relationship with a single feature, we would encourage thinking of a connection as the entire integration with that other service. Users should have full control over that connection status.

The connection should remain active unless the user explicitly disconnects it (in which case IFTTT will send a [`/disabled` webhook](https://platform.ifttt.com/docs/connect_api#disabled-webhook)).