### PR TITLE
Add support to generated signed Grocery Express apk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ local.properties
 
 # Mac OS
 .DS_Store
+
+# Secret stuff
+*.keystore
+env
+signing.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 28
     buildToolsVersion '28.0.3'
+
     defaultConfig {
         applicationId "com.ifttt.groceryexpress"
         minSdkVersion 18
@@ -12,8 +13,19 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
+    signingConfigs {
+        production {
+            storeFile file("ifttt.keystore")
+            storePassword rootProject.storePassword
+            keyAlias "ifttt"
+            keyPassword rootProject.prodKeyPassword
+        }
+    }
+    
     buildTypes {
         release {
+            signingConfig signingConfigs.production
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,15 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
+Properties props = new Properties()
+props.load(new FileInputStream(file("signing.properties")))
+
 ext {
     libVersion = '2.1.0'
     okHttpVersion = '3.14.2'
     retrofitVersion = '2.6.0'
     moshiVersion = '1.8.0'
     workManagerVersion = '2.3.1'
+    storePassword = props["storePassword"]
+    prodKeyPassword = props["prodKeyPassword"]
 }


### PR DESCRIPTION
This is necessary to setup internal distribution through Google Play Store. 