### PR TITLE
Only register geofences if connection/feature enabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'

--- a/connect-api/src/main/java/com/ifttt/connect/ConnectionJsonAdapter.java
+++ b/connect-api/src/main/java/com/ifttt/connect/ConnectionJsonAdapter.java
@@ -32,8 +32,9 @@ final class ConnectionJsonAdapter {
         "user_connection"
     );
     private final JsonReader.Options userConnectionOptions = JsonReader.Options.of("user_features");
-    private final JsonReader.Options featureOptions = JsonReader.Options.of("id",
+    private final JsonReader.Options userFeatureOptions = JsonReader.Options.of("id",
         "feature_id",
+        "enabled",
         "user_feature_triggers",
         "user_feature_queries",
         "user_feature_actions"
@@ -152,11 +153,12 @@ final class ConnectionJsonAdapter {
             while (jsonReader.hasNext()) {
                 String id = null;
                 String featureId = null;
+                boolean enabled = true;
                 List<UserFeatureStep> steps = new ArrayList<>();
 
                 jsonReader.beginObject();
                 while (jsonReader.hasNext()) {
-                    int featureIndex = jsonReader.selectName(featureOptions);
+                    int featureIndex = jsonReader.selectName(userFeatureOptions);
                     switch (featureIndex) {
                         case 0:
                             id = jsonReader.nextString();
@@ -165,6 +167,9 @@ final class ConnectionJsonAdapter {
                             featureId = jsonReader.nextString();
                             break;
                         case 2:
+                            enabled = jsonReader.nextBoolean();
+                            break;
+                        case 3:
                             // Triggers
                             parseUserSteps(jsonReader,
                                 FeatureStep.StepType.Trigger,
@@ -175,7 +180,7 @@ final class ConnectionJsonAdapter {
                                 steps
                             );
                             break;
-                        case 3:
+                        case 4:
                             // Queries
                             parseUserSteps(jsonReader,
                                 FeatureStep.StepType.Query,
@@ -186,7 +191,7 @@ final class ConnectionJsonAdapter {
                                 steps
                             );
                             break;
-                        case 4:
+                        case 5:
                             // Actions.
                             parseUserSteps(jsonReader,
                                 FeatureStep.StepType.Action,
@@ -206,7 +211,7 @@ final class ConnectionJsonAdapter {
                 checkNonNull(id);
                 checkNonNull(featureId);
 
-                userFeatures.add(new UserFeature(id, featureId, steps));
+                userFeatures.add(new UserFeature(id, featureId, enabled, steps));
             }
             jsonReader.endArray();
         }

--- a/connect-api/src/main/java/com/ifttt/connect/UserFeature.java
+++ b/connect-api/src/main/java/com/ifttt/connect/UserFeature.java
@@ -12,17 +12,20 @@ public final class UserFeature implements Parcelable  {
 
     public final String id;
     public final String featureId;
+    public final boolean enabled;
     public final List<UserFeatureStep> userFeatureSteps;
 
-    public UserFeature(String id, String featureId, List<UserFeatureStep> userFeatureSteps) {
+    public UserFeature(String id, String featureId, boolean enabled, List<UserFeatureStep> userFeatureSteps) {
         this.id = id;
         this.featureId = featureId;
+        this.enabled = enabled;
         this.userFeatureSteps = userFeatureSteps;
     }
 
     protected UserFeature(Parcel in) {
         id = in.readString();
         featureId = in.readString();
+        enabled = in.readBoolean();
         userFeatureSteps = in.createTypedArrayList(UserFeatureStep.CREATOR);
     }
 
@@ -47,6 +50,7 @@ public final class UserFeature implements Parcelable  {
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(id);
         dest.writeString(featureId);
+        dest.writeBoolean(enabled);
         dest.writeTypedList(userFeatureSteps);
     }
 }

--- a/connect-api/src/test/resources/connection.json
+++ b/connect-api/src/test/resources/connection.json
@@ -139,6 +139,7 @@
         "id": "5c7f6d49-5fa9-4305-a7db-39ca38484e6e",
         "feature_id": "pmtch6832j",
         "user_fields": [],
+        "enabled": true,
         "user_feature_triggers": [
           {
             "feature_trigger_id": "606",
@@ -181,6 +182,7 @@
         "id": "6888021f-47b0-4d3a-8058-bbf57e260173",
         "feature_id": "sxfkrzwujy",
         "user_fields": [],
+        "enabled": true,
         "user_feature_triggers": [
           {
             "feature_trigger_id": "564",

--- a/connect-button/src/test/resources/connection.json
+++ b/connect-button/src/test/resources/connection.json
@@ -139,6 +139,7 @@
         "id": "5c7f6d49-5fa9-4305-a7db-39ca38484e6e",
         "feature_id": "pmtch6832j",
         "user_fields": [],
+        "enabled": true,
         "user_feature_triggers": [
           {
             "feature_trigger_id": "606",
@@ -181,6 +182,7 @@
         "id": "6888021f-47b0-4d3a-8058-bbf57e260173",
         "feature_id": "sxfkrzwujy",
         "user_fields": [],
+        "enabled": true,
         "user_feature_triggers": [
           {
             "feature_trigger_id": "564",

--- a/connect-button/src/test/resources/connection_enabled.json
+++ b/connect-button/src/test/resources/connection_enabled.json
@@ -139,6 +139,7 @@
         "id": "5c7f6d49-5fa9-4305-a7db-39ca38484e6e",
         "feature_id": "pmtch6832j",
         "user_fields": [],
+        "enabled": true,
         "user_feature_triggers": [
           {
             "feature_trigger_id": "606",
@@ -181,6 +182,7 @@
         "id": "6888021f-47b0-4d3a-8058-bbf57e260173",
         "feature_id": "sxfkrzwujy",
         "user_fields": [],
+        "enabled": true,
         "user_feature_triggers": [
           {
             "feature_trigger_id": "564",

--- a/connect-location/src/main/java/com/ifttt/location/AwarenessGeofenceProvider.java
+++ b/connect-location/src/main/java/com/ifttt/location/AwarenessGeofenceProvider.java
@@ -28,7 +28,7 @@ import java.util.Set;
  *
  * The process includes:
  * - registering any new geofences
- * - un-regisstering any outdated geofences
+ * - un-registering any outdated geofences
  */
 final class AwarenessGeofenceProvider implements GeofenceProvider {
 
@@ -130,10 +130,6 @@ final class AwarenessGeofenceProvider implements GeofenceProvider {
                     for (UserFeatureField userFeatureField : step.fields) {
                         if (!locationFieldTypesList.contains(userFeatureField.fieldType)) {
                             continue;
-                        }
-
-                        if (!(userFeatureField.value instanceof LocationFieldValue)) {
-                            throw new IllegalStateException("Location field should have LocationFieldValue data.");
                         }
 
                         LocationFieldValue region = (LocationFieldValue) userFeatureField.value;

--- a/connect-location/src/main/java/com/ifttt/location/AwarenessGeofenceProvider.java
+++ b/connect-location/src/main/java/com/ifttt/location/AwarenessGeofenceProvider.java
@@ -3,8 +3,10 @@ package com.ifttt.location;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.awareness.Awareness;
 import com.google.android.gms.awareness.FenceClient;
+import com.google.android.gms.awareness.fence.AwarenessFence;
 import com.google.android.gms.awareness.fence.FenceQueryRequest;
 import com.google.android.gms.awareness.fence.FenceUpdateRequest;
 import com.google.android.gms.awareness.fence.LocationFence;
@@ -14,11 +16,20 @@ import com.ifttt.connect.LocationFieldValue;
 import com.ifttt.connect.UserFeature;
 import com.ifttt.connect.UserFeatureField;
 import com.ifttt.connect.UserFeatureStep;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * {@link GeofenceProvider} implementation using {@link Awareness} API. This implementation processes a list of
+ * {@link UserFeature} from a {@link Connection}, extract all {@link LocationFieldValue} that is currently enabled for
+ * the user, and then use them as the geofence setup.
+ *
+ * The process includes:
+ * - registering any new geofences
+ * - un-regisstering any outdated geofences
+ */
 final class AwarenessGeofenceProvider implements GeofenceProvider {
 
     private final static int REQUEST_CODE_ENTER = 1001;
@@ -40,105 +51,145 @@ final class AwarenessGeofenceProvider implements GeofenceProvider {
     AwarenessGeofenceProvider(Context context) {
         this.fenceClient = Awareness.getFenceClient(context);
 
-        exitPendingIntent = PendingIntent.getBroadcast(
-                context,
-                REQUEST_CODE_EXIT,
-                new Intent(context, AwarenessExitReceiver.class),
-                PendingIntent.FLAG_UPDATE_CURRENT
+        exitPendingIntent = PendingIntent.getBroadcast(context,
+            REQUEST_CODE_EXIT,
+            new Intent(context, AwarenessExitReceiver.class),
+            PendingIntent.FLAG_UPDATE_CURRENT
         );
 
-        enterPendingIntent = PendingIntent.getBroadcast(
-                context,
-                REQUEST_CODE_ENTER,
-                new Intent(context, AwarenessEnterReceiver.class),
-                PendingIntent.FLAG_UPDATE_CURRENT
+        enterPendingIntent = PendingIntent.getBroadcast(context,
+            REQUEST_CODE_ENTER,
+            new Intent(context, AwarenessEnterReceiver.class),
+            PendingIntent.FLAG_UPDATE_CURRENT
         );
     }
 
     @Override
     public void updateGeofences(final Connection connection) {
-        final List<String> updatedIds = new ArrayList<>();
+        fenceClient.queryFences(FenceQueryRequest.all()).addOnSuccessListener(fenceQueryResponse -> {
+            FenceUpdateRequest.Builder requestBuilder = new FenceUpdateRequest.Builder();
+            diffFences(connection.status,
+                connection.features,
+                fenceQueryResponse.getFenceStateMap().getFenceKeys(),
+                enterPendingIntent,
+                exitPendingIntent,
+                new DiffCallback() {
+                    @Override
+                    public void onAddFence(String key, AwarenessFence value, PendingIntent pendingIntent) {
+                        requestBuilder.addFence(key, value, pendingIntent);
+                    }
 
-        List<UserFeatureField> userFeatureFields = new ArrayList<>();
+                    @Override
+                    public void onRemoveFence(String key) {
+                        requestBuilder.removeFence(key);
+                    }
+                }
+            );
+            fenceClient.updateFences(requestBuilder.build());
+        });
+    }
 
-        for (Feature feature : connection.features) {
-            if (feature.userFeatures == null) {
+    private static String getEnterFenceKey(String id) {
+        return id.concat("/enter");
+    }
+
+    private static String getExitFenceKey(String id) {
+        return id.concat("/exit");
+    }
+
+    interface DiffCallback {
+        void onAddFence(String key, AwarenessFence value, PendingIntent pendingIntent);
+
+        void onRemoveFence(String key);
+    }
+
+    @VisibleForTesting
+    static void diffFences(
+        Connection.Status state,
+        List<Feature> features,
+        Set<String> registeredFenceKeys,
+        PendingIntent enterPendingIntent,
+        PendingIntent exitPendingIntent,
+        DiffCallback callback
+    ) {
+        Set<String> fenceKeysToRemove = new HashSet<>(registeredFenceKeys);
+
+        for (Feature feature : features) {
+            if (feature.userFeatures == null || state != Connection.Status.enabled) {
+                // Skip registration if the UserFeature is null or the connection is not enabled.
                 continue;
             }
 
             for (UserFeature userFeature : feature.userFeatures) {
+                if (!userFeature.enabled) {
+                    // Skip processing disabled UserFeatureSteps.
+                    continue;
+                }
+
                 for (UserFeatureStep step : userFeature.userFeatureSteps) {
                     for (UserFeatureField userFeatureField : step.fields) {
                         if (!locationFieldTypesList.contains(userFeatureField.fieldType)) {
                             continue;
                         }
 
-                        userFeatureFields.add(userFeatureField);
-                        if (userFeatureField.fieldType.equals(FIELD_TYPE_LOCATION_ENTER_EXIT)) {
-                            updatedIds.add(getEnterFenceKey(userFeatureField.fieldId));
-                            updatedIds.add(getExitFenceKey(userFeatureField.fieldId));
-                        } else {
-                            updatedIds.add(userFeatureField.fieldId);
+                        if (!(userFeatureField.value instanceof LocationFieldValue)) {
+                            throw new IllegalStateException("Location field should have LocationFieldValue data.");
+                        }
+
+                        LocationFieldValue region = (LocationFieldValue) userFeatureField.value;
+                        switch (userFeatureField.fieldType) {
+                            case FIELD_TYPE_LOCATION_ENTER:
+                                if (!fenceKeysToRemove.contains(step.id)) {
+                                    callback.onAddFence(step.id,
+                                        LocationFence.entering(region.lat, region.lng, region.radius),
+                                        enterPendingIntent
+                                    );
+                                } else {
+                                    fenceKeysToRemove.remove(step.id);
+                                }
+                                break;
+                            case FIELD_TYPE_LOCATION_EXIT:
+                                if (!fenceKeysToRemove.contains(step.id)) {
+                                    callback.onAddFence(step.id,
+                                        LocationFence.exiting(region.lat, region.lng, region.radius),
+                                        exitPendingIntent
+                                    );
+                                } else {
+                                    fenceKeysToRemove.remove(step.id);
+                                }
+                                break;
+                            case FIELD_TYPE_LOCATION_ENTER_EXIT:
+                                String enterFenceKey = getEnterFenceKey(step.id);
+                                if (!fenceKeysToRemove.contains(enterFenceKey)) {
+                                    callback.onAddFence(enterFenceKey,
+                                        LocationFence.entering(region.lat, region.lng, region.radius),
+                                        enterPendingIntent
+                                    );
+                                } else {
+                                    fenceKeysToRemove.remove(enterFenceKey);
+                                }
+
+                                String exitFenceKey = getExitFenceKey(step.id);
+                                if (!fenceKeysToRemove.contains(exitFenceKey)) {
+                                    callback.onAddFence(exitFenceKey,
+                                        LocationFence.exiting(region.lat, region.lng, region.radius),
+                                        exitPendingIntent
+                                    );
+                                } else {
+                                    fenceKeysToRemove.remove(exitFenceKey);
+                                }
+                                break;
+                            default:
+                                // No-op for other location types.
                         }
                     }
                 }
             }
         }
 
-
-        fenceClient.queryFences(
-                FenceQueryRequest.all()).addOnSuccessListener(fenceQueryResponse -> {
-            FenceUpdateRequest.Builder requestBuilder = new FenceUpdateRequest.Builder();
-            Set<String> fenceKeys = fenceQueryResponse.getFenceStateMap().getFenceKeys();
-
-            for (String fenceKey: fenceKeys) {
-                if (!updatedIds.contains(fenceKey)) {
-                    requestBuilder.removeFence(fenceKey);
-                }
-            }
-
-            for (UserFeatureField userFeatureField: userFeatureFields) {
-                LocationFieldValue region = (LocationFieldValue) userFeatureField.value;
-
-                switch (userFeatureField.fieldType) {
-                    case FIELD_TYPE_LOCATION_ENTER:
-                        requestBuilder.addFence(
-                                userFeatureField.fieldId,
-                                LocationFence.entering(region.lat, region.lng, region.radius),
-                                enterPendingIntent
-                        );
-                        break;
-
-                    case FIELD_TYPE_LOCATION_EXIT:
-                        requestBuilder.addFence(
-                                userFeatureField.fieldId,
-                                LocationFence.exiting(region.lat, region.lng, region.radius),
-                                exitPendingIntent
-                        );
-                        break;
-
-                    case FIELD_TYPE_LOCATION_ENTER_EXIT:
-                        requestBuilder.addFence(
-                                getExitFenceKey(userFeatureField.fieldId),
-                                LocationFence.exiting(region.lat, region.lng, region.radius),
-                                exitPendingIntent
-                        );
-                        requestBuilder.addFence(
-                                getEnterFenceKey(userFeatureField.fieldId),
-                                LocationFence.entering(region.lat, region.lng, region.radius),
-                                enterPendingIntent
-                        );
-                }
-                fenceClient.updateFences(requestBuilder.build());
-            }
-        });
-    }
-
-    private String getEnterFenceKey(String id) {
-        return id.concat("/enter");
-    }
-
-    private String getExitFenceKey(String id) {
-        return id.concat("/exit");
+        // Unregister outdated geofences.
+        for (String fenceKey : fenceKeysToRemove) {
+            callback.onRemoveFence(fenceKey);
+        }
     }
 }

--- a/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
@@ -29,21 +29,31 @@ public final class ConnectLocation implements ButtonStateChangeListener {
     private final String WORK_ID_CONNECTION_POLLING = "connection_refresh_polling";
     private final long CONNECTION_REFRESH_POLLING_INTERVAL = 1;
 
-    public static synchronized ConnectLocation init(Context context, String connectionId,
-        CredentialsProvider credentialsProvider, ConnectionApiClient apiClient) {
+    public static synchronized ConnectLocation init(
+        Context context, String connectionId, CredentialsProvider credentialsProvider, ConnectionApiClient apiClient
+    ) {
         if (INSTANCE == null) {
-            INSTANCE = new ConnectLocation(connectionId, new AwarenessGeofenceProvider(context),
-                credentialsProvider, apiClient, WorkManager.getInstance(context));
+            INSTANCE = new ConnectLocation(connectionId,
+                new AwarenessGeofenceProvider(context),
+                credentialsProvider,
+                apiClient,
+                WorkManager.getInstance(context)
+            );
         }
         return INSTANCE;
     }
 
-    public static synchronized ConnectLocation init(Context context, String connectionId,
-            CredentialsProvider credentialsProvider) {
+    public static synchronized ConnectLocation init(
+        Context context, String connectionId, CredentialsProvider credentialsProvider
+    ) {
         if (INSTANCE == null) {
             ConnectionApiClient.Builder clientBuilder = new ConnectionApiClient.Builder(context);
-            INSTANCE = new ConnectLocation(connectionId, new AwarenessGeofenceProvider(context),
-                    credentialsProvider, clientBuilder.build(), WorkManager.getInstance(context));
+            INSTANCE = new ConnectLocation(connectionId,
+                new AwarenessGeofenceProvider(context),
+                credentialsProvider,
+                clientBuilder.build(),
+                WorkManager.getInstance(context)
+            );
         }
         return INSTANCE;
     }
@@ -60,36 +70,44 @@ public final class ConnectLocation implements ButtonStateChangeListener {
     }
 
     @VisibleForTesting
-    ConnectLocation(String connectionId, GeofenceProvider geofenceProvider,
-            CredentialsProvider credentialsProvider, ConnectionApiClient connectionApiClient,
-            WorkManager workManager) {
+    ConnectLocation(
+        String connectionId,
+        GeofenceProvider geofenceProvider,
+        CredentialsProvider credentialsProvider,
+        ConnectionApiClient connectionApiClient,
+        WorkManager workManager
+    ) {
         this.connectionId = connectionId;
         this.geofenceProvider = geofenceProvider;
         this.credentialsProvider = credentialsProvider;
         this.connectionApiClient = connectionApiClient;
         this.workManager = workManager;
+
         setUpPolling();
     }
 
     private void setUpPolling() {
-        Constraints constraints =
-                new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
+        Constraints constraints = new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
         workManager.enqueueUniquePeriodicWork(WORK_ID_CONNECTION_POLLING,
-                ExistingPeriodicWorkPolicy.KEEP,
-                new PeriodicWorkRequest.Builder(ConnectionRefresher.class, CONNECTION_REFRESH_POLLING_INTERVAL, TimeUnit.HOURS)
-                        .setConstraints(constraints)
-                        .build()
+            ExistingPeriodicWorkPolicy.KEEP,
+            new PeriodicWorkRequest.Builder(
+                ConnectionRefresher.class,
+                CONNECTION_REFRESH_POLLING_INTERVAL,
+                TimeUnit.HOURS
+            ).setConstraints(constraints).build()
         );
     }
 
     @Override
-    public void onStateChanged(ConnectButtonState currentState, ConnectButtonState previousState,
-            Connection connection) {
-            if (currentState == ConnectButtonState.Enabled
-                    || currentState == ConnectButtonState.Disabled
-                    || currentState == ConnectButtonState.Initial) {
-                geofenceProvider.updateGeofences(connection);
-            }
+    public void onStateChanged(
+        ConnectButtonState currentState, ConnectButtonState previousState, Connection connection
+    ) {
+        if (currentState == ConnectButtonState.Enabled
+            || currentState == ConnectButtonState.Disabled
+            || currentState == ConnectButtonState.Initial) {
+            geofenceProvider.updateGeofences(connection);
+        }
+
         if (currentState == ConnectButtonState.Enabled) {
             setUpPolling();
         }

--- a/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
@@ -30,10 +30,10 @@ public final class ConnectLocation implements ButtonStateChangeListener {
     private final long CONNECTION_REFRESH_POLLING_INTERVAL = 1;
 
     public static synchronized ConnectLocation init(Context context, String connectionId,
-            CredentialsProvider credentialsProvider, ConnectionApiClient apiClient) {
+        CredentialsProvider credentialsProvider, ConnectionApiClient apiClient) {
         if (INSTANCE == null) {
             INSTANCE = new ConnectLocation(connectionId, new AwarenessGeofenceProvider(context),
-                    credentialsProvider, apiClient, WorkManager.getInstance(context));
+                credentialsProvider, apiClient, WorkManager.getInstance(context));
         }
         return INSTANCE;
     }

--- a/connect-location/src/main/java/com/ifttt/location/GeofenceProvider.java
+++ b/connect-location/src/main/java/com/ifttt/location/GeofenceProvider.java
@@ -2,8 +2,11 @@ package com.ifttt.location;
 
 import com.ifttt.connect.Connection;
 
+/**
+ * Abstract type for a geofence functionality provider. The type is responsbile for setting up geofences given a
+ * {@link Connection}.
+ */
 interface GeofenceProvider {
 
     void updateGeofences(final Connection connection);
-
 }

--- a/connect-location/src/test/java/com/ifttt/location/AwarenessGeofenceProviderTest.java
+++ b/connect-location/src/test/java/com/ifttt/location/AwarenessGeofenceProviderTest.java
@@ -1,0 +1,249 @@
+package com.ifttt.location;
+
+import android.app.PendingIntent;
+import android.content.Intent;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.android.gms.awareness.fence.AwarenessFence;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.ifttt.connect.Connection;
+import com.ifttt.connect.Feature;
+import com.ifttt.connect.FeatureStep;
+import com.ifttt.connect.LocationFieldValue;
+import com.ifttt.connect.UserFeature;
+import com.ifttt.connect.UserFeatureField;
+import com.ifttt.connect.UserFeatureStep;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+@RunWith(AndroidJUnit4.class)
+public final class AwarenessGeofenceProviderTest {
+
+    private LocationFieldValue value = new LocationFieldValue(1.0D, 1.0D, 100D, "");
+    private UserFeatureField<LocationFieldValue> field = new UserFeatureField<>(value, "LOCATION_ENTER", "id");
+    private UserFeatureStep step = new UserFeatureStep(FeatureStep.StepType.Trigger,
+        "step_id",
+        "stepId", ImmutableList.of(field)
+    );
+    private UserFeature userFeature = new UserFeature("id", "featureId", true, ImmutableList.of(step));
+    private Feature feature = new Feature("id", "title", "description", "iconUrl", ImmutableList.of(userFeature));
+
+    private PendingIntent enter = PendingIntent.getBroadcast(ApplicationProvider.getApplicationContext(),
+        0,
+        new Intent("action_1"),
+        PendingIntent.FLAG_UPDATE_CURRENT
+    );
+    private PendingIntent exit = PendingIntent.getBroadcast(ApplicationProvider.getApplicationContext(),
+        1,
+        new Intent("action_2"),
+        PendingIntent.FLAG_UPDATE_CURRENT
+    );
+
+    @Test
+    public void shouldRegisterEnterGeofence() {
+        AwarenessGeofenceProvider.diffFences(
+            Connection.Status.enabled,
+            ImmutableList.of(feature),
+            ImmutableSet.of(),
+            enter,
+            exit,
+            new AwarenessGeofenceProvider.DiffCallback() {
+                @Override
+                public void onAddFence(
+                    String key, AwarenessFence value, PendingIntent pendingIntent
+                ) {
+                    assertThat(key).isEqualTo("step_id");
+                    assertThat(pendingIntent).isEqualTo(enter);
+                }
+
+                @Override
+                public void onRemoveFence(String key) {
+                    fail();
+                }
+            }
+        );
+    }
+
+    @Test
+    public void shouldRegisterExitGeofence() {
+        UserFeatureField<LocationFieldValue> field = new UserFeatureField<>(value, "LOCATION_EXIT", "id");
+        UserFeatureStep step = new UserFeatureStep(FeatureStep.StepType.Trigger,
+            "step_id",
+            "stepId", ImmutableList.of(field)
+        );
+        UserFeature userFeature = new UserFeature("id", "featureId", true, ImmutableList.of(step));
+        Feature feature = new Feature("id", "title", "description", "iconUrl", ImmutableList.of(userFeature));
+
+        AwarenessGeofenceProvider.diffFences(
+            Connection.Status.enabled,
+            ImmutableList.of(feature),
+            ImmutableSet.of(),
+            enter,
+            exit,
+            new AwarenessGeofenceProvider.DiffCallback() {
+                @Override
+                public void onAddFence(
+                    String key, AwarenessFence value, PendingIntent pendingIntent
+                ) {
+                    assertThat(key).isEqualTo("step_id");
+                    assertThat(pendingIntent).isEqualTo(exit);
+                }
+
+                @Override
+                public void onRemoveFence(String key) {
+                    fail();
+                }
+            }
+        );
+    }
+
+    @Test
+    public void shouldRegisterEnterExit() {
+        AtomicReference<List<String>> keysRef = new AtomicReference<>(new ArrayList<>());
+        AtomicReference<List<PendingIntent>> pendingIntentRef = new AtomicReference<>(new ArrayList<>());
+        UserFeatureField<LocationFieldValue> field = new UserFeatureField<>(value, "LOCATION_ENTER_OR_EXIT", "id");
+        UserFeatureStep step = new UserFeatureStep(FeatureStep.StepType.Trigger,
+            "step_id",
+            "stepId", ImmutableList.of(field)
+        );
+        UserFeature userFeature = new UserFeature("id", "featureId", true, ImmutableList.of(step));
+        Feature feature = new Feature("id", "title", "description", "iconUrl", ImmutableList.of(userFeature));
+
+        AwarenessGeofenceProvider.diffFences(
+            Connection.Status.enabled,
+            ImmutableList.of(feature),
+            ImmutableSet.of(),
+            enter,
+            exit,
+            new AwarenessGeofenceProvider.DiffCallback() {
+                @Override
+                public void onAddFence(
+                    String key, AwarenessFence value, PendingIntent pendingIntent
+                ) {
+                    keysRef.get().add(key);
+                    pendingIntentRef.get().add(pendingIntent);
+                }
+
+                @Override
+                public void onRemoveFence(String key) {
+                    fail();
+                }
+            }
+        );
+
+        assertThat(keysRef.get().get(0)).isEqualTo("step_id/enter");
+        assertThat(keysRef.get().get(1)).isEqualTo("step_id/exit");
+        assertThat(pendingIntentRef.get().get(0)).isEqualTo(enter);
+        assertThat(pendingIntentRef.get().get(1)).isEqualTo(exit);
+    }
+
+    @Test
+    public void shouldNotRegisterExistingGeofences() {
+        AwarenessGeofenceProvider.diffFences(
+            Connection.Status.enabled,
+            ImmutableList.of(feature),
+            ImmutableSet.of("step_id"),
+            enter,
+            exit,
+            new AwarenessGeofenceProvider.DiffCallback() {
+                @Override
+                public void onAddFence(
+                    String key, AwarenessFence value, PendingIntent pendingIntent
+                ) {
+                    fail();
+                }
+
+                @Override
+                public void onRemoveFence(String key) {
+                    fail();
+                }
+            }
+        );
+    }
+
+    @Test
+    public void shouldNotRegisterWhenConnectionDisabled() {
+        AwarenessGeofenceProvider.diffFences(
+            Connection.Status.disabled,
+            ImmutableList.of(feature),
+            ImmutableSet.of(),
+            enter,
+            exit,
+            new AwarenessGeofenceProvider.DiffCallback() {
+                @Override
+                public void onAddFence(
+                    String key, AwarenessFence value, PendingIntent pendingIntent
+                ) {
+                    fail();
+                }
+
+                @Override
+                public void onRemoveFence(String key) {
+                    fail();
+                }
+            }
+        );
+    }
+
+    @Test
+    public void shouldNotRegisterWhenFeatureDisabled() {
+        UserFeatureStep step = new UserFeatureStep(FeatureStep.StepType.Trigger,
+            "step_id",
+            "stepId", ImmutableList.of(field)
+        );
+        UserFeature userFeature = new UserFeature("id", "featureId", false, ImmutableList.of(step));
+        Feature feature = new Feature("id", "title", "description", "iconUrl", ImmutableList.of(userFeature));
+
+        AwarenessGeofenceProvider.diffFences(
+            Connection.Status.disabled,
+            ImmutableList.of(feature),
+            ImmutableSet.of(),
+            enter,
+            exit,
+            new AwarenessGeofenceProvider.DiffCallback() {
+                @Override
+                public void onAddFence(
+                    String key, AwarenessFence value, PendingIntent pendingIntent
+                ) {
+                    fail();
+                }
+
+                @Override
+                public void onRemoveFence(String key) {
+                    fail();
+                }
+            }
+        );
+    }
+
+    @Test
+    public void shouldRemoveOutdatedGeofences() {
+        AwarenessGeofenceProvider.diffFences(
+            Connection.Status.enabled,
+            ImmutableList.of(),
+            ImmutableSet.of("step_id"),
+            enter,
+            exit,
+            new AwarenessGeofenceProvider.DiffCallback() {
+                @Override
+                public void onAddFence(
+                    String key, AwarenessFence value, PendingIntent pendingIntent
+                ) {
+                    fail();
+                }
+
+                @Override
+                public void onRemoveFence(String key) {
+                    assertThat(key).isEqualTo("step_id");
+                }
+            }
+        );
+    }
+}

--- a/connect-location/src/test/java/com/ifttt/location/ConnectLocationTest.java
+++ b/connect-location/src/test/java/com/ifttt/location/ConnectLocationTest.java
@@ -71,12 +71,11 @@ public class ConnectLocationTest {
     @Test
     public void shouldUpdateGeofencesWhenEnabled() {
         AtomicBoolean ref = new AtomicBoolean();
-        ConnectLocation location = new ConnectLocation(
-                "id",
-                features -> ref.set(true),
-                credentialsProvider,
-                apiClient,
-                workManager
+        ConnectLocation location = new ConnectLocation("id",
+            connection -> ref.set(true),
+            credentialsProvider,
+            apiClient,
+            workManager
         );
 
         location.onStateChanged(ConnectButtonState.Enabled, ConnectButtonState.Initial, connection);
@@ -86,12 +85,11 @@ public class ConnectLocationTest {
     @Test
     public void shouldUpdateGeofencesWhenDisabled() {
         AtomicBoolean ref = new AtomicBoolean();
-        ConnectLocation location = new ConnectLocation(
-                "id",
-                features -> ref.set(true),
-                credentialsProvider,
-                apiClient,
-                workManager
+        ConnectLocation location = new ConnectLocation("id",
+            connection -> ref.set(true),
+            credentialsProvider,
+            apiClient,
+            workManager
         );
 
         location.onStateChanged(ConnectButtonState.Disabled, ConnectButtonState.Enabled, connection);
@@ -101,12 +99,11 @@ public class ConnectLocationTest {
     @Test
     public void shouldUpdateGeofencesWhenInitial() {
         AtomicBoolean ref = new AtomicBoolean();
-        ConnectLocation location = new ConnectLocation(
-                "id",
-                features -> ref.set(true),
-                credentialsProvider,
-                apiClient,
-                workManager
+        ConnectLocation location = new ConnectLocation("id",
+            connection -> ref.set(true),
+            credentialsProvider,
+            apiClient,
+            workManager
         );
 
         location.onStateChanged(ConnectButtonState.Initial, ConnectButtonState.Enabled, connection);
@@ -115,12 +112,11 @@ public class ConnectLocationTest {
 
     @Test
     public void shouldNotUpdateGeofencesWhenCreateAccountOrLogin() {
-        ConnectLocation location = new ConnectLocation(
-                "id",
-                connection -> fail(),
-                credentialsProvider,
-                apiClient,
-                workManager
+        ConnectLocation location = new ConnectLocation("id",
+            connection -> fail(),
+            credentialsProvider,
+            apiClient,
+            workManager
         );
 
         location.onStateChanged(ConnectButtonState.CreateAccount, ConnectButtonState.Initial, connection);


### PR DESCRIPTION
We should only register geofences if the connection and the user feature is currently enabled, and should unregsiter geofences for the fields from disabled feature/connection.

Also did some refactoring to AwarenessGeofenceProvider and added some tests for the diff logic.