### PR TITLE
Add a default button state to ConnectButton

### DIFF
--- a/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
@@ -76,6 +76,7 @@ import static com.ifttt.connect.ui.ConnectButtonState.Disabled;
 import static com.ifttt.connect.ui.ConnectButtonState.Enabled;
 import static com.ifttt.connect.ui.ConnectButtonState.Initial;
 import static com.ifttt.connect.ui.ConnectButtonState.Login;
+import static com.ifttt.connect.ui.ConnectButtonState.Unknown;
 
 /**
  * Internal implementation of a Connect Button widget, all of the states and transitions are implemented here.
@@ -116,7 +117,7 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
     private final int borderSize = getResources().getDimensionPixelSize(R.dimen.ifttt_button_border_width);
     private final Drawable borderDrawable = ContextCompat.getDrawable(getContext(), R.drawable.ifttt_button_border);
 
-    private ConnectButtonState buttonState = Initial;
+    private ConnectButtonState buttonState = Unknown;
     private Connection connection;
     private Service worksWithService;
 

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButtonState.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButtonState.java
@@ -27,5 +27,10 @@ public enum ConnectButtonState {
     /**
      * A button stat for displaying a Connection that is disabled.
      */
-    Disabled
+    Disabled,
+
+    /**
+     * Default button state.
+     */
+    Unknown
 }


### PR DESCRIPTION
I noticed that the behavior of the ButtonStateChangeListener is not consistent where the button is set up, i.e it doesn't get invoked when the button is in its initial state, but will be invoked when the connection's status changes to enabled or disabled. This is because the default value for the button state is `Initial`.

This change adds a "unknown" state as the default value for a ConnectButton.

We should document this in the changelog.