### PR TITLE
Add support for skipping connection configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'

--- a/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
@@ -262,9 +262,10 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
      * @param inviteCode Optional invite code to access an IFTTT service that has not yet published.
      */
     void setup(String email, ConnectionApiClient connectionApiClient, Uri redirectUri,
-            CredentialsProvider credentialsProvider, @Nullable String inviteCode) {
+            CredentialsProvider credentialsProvider, @Nullable String inviteCode, boolean skipConfiguration) {
         buttonApiHelper =
-                new ButtonApiHelper(connectionApiClient, redirectUri, inviteCode, credentialsProvider, getLifecycle());
+                new ButtonApiHelper(connectionApiClient, redirectUri, inviteCode, credentialsProvider, getLifecycle(),
+                    skipConfiguration);
         emailEdt.setText(email);
     }
 

--- a/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/BaseConnectButton.java
@@ -260,12 +260,20 @@ final class BaseConnectButton extends LinearLayout implements LifecycleOwner {
      * @param credentialsProvider CredentialsProvider implementation that returns your user's OAuth code. The code will be
      * used to automatically connect your service on IFTTT for this user.
      * @param inviteCode Optional invite code to access an IFTTT service that has not yet published.
+     * @param skipConnectionConfiguration Optional flag that configures the ConnectButton so that the connection
+     * configuration step is skipped.
      */
-    void setup(String email, ConnectionApiClient connectionApiClient, Uri redirectUri,
-            CredentialsProvider credentialsProvider, @Nullable String inviteCode, boolean skipConfiguration) {
+    void setup(
+        String email,
+        ConnectionApiClient connectionApiClient,
+        Uri redirectUri,
+        CredentialsProvider credentialsProvider,
+        @Nullable String inviteCode,
+        boolean skipConnectionConfiguration
+    ) {
         buttonApiHelper =
                 new ButtonApiHelper(connectionApiClient, redirectUri, inviteCode, credentialsProvider, getLifecycle(),
-                    skipConfiguration);
+                    skipConnectionConfiguration);
         emailEdt.setText(email);
     }
 

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
@@ -38,6 +38,7 @@ final class ButtonApiHelper {
     private final CredentialsProvider credentialsProvider;
     private final Lifecycle lifecycle;
     private final Uri redirectUri;
+    private final boolean skipConfiguration;
     @Nullable private final String inviteCode;
 
     @Nullable private String oAuthCode;
@@ -56,12 +57,13 @@ final class ButtonApiHelper {
         Uri redirectUri,
         @Nullable String inviteCode,
         CredentialsProvider provider,
-        Lifecycle lifecycle
+        Lifecycle lifecycle, boolean skipConfiguration
     ) {
         this.lifecycle = lifecycle;
         this.redirectUri = redirectUri;
         this.inviteCode = inviteCode;
         this.connectionApiClient = client;
+        this.skipConfiguration = skipConfiguration;
         credentialsProvider = provider;
     }
 
@@ -167,7 +169,8 @@ final class ButtonApiHelper {
             userLogin,
             anonymousId,
             oAuthCode,
-            inviteCode
+            inviteCode,
+            skipConfiguration
         );
         CustomTabsIntent intent = new CustomTabsIntent.Builder().build();
         intent.launchUrl(context, uri);
@@ -189,7 +192,8 @@ final class ButtonApiHelper {
             userLogin,
             anonymousId,
             oAuthCode,
-            inviteCode
+            inviteCode,
+            skipConfiguration
         ));
         launchIntent.setPackage(PACKAGE_NAME_IFTTT);
 
@@ -229,7 +233,8 @@ final class ButtonApiHelper {
         @Nullable String userLogin,
         String anonymousId,
         @Nullable String oAuthCode,
-        @Nullable String inviteCode
+        @Nullable String inviteCode,
+        boolean skipConfiguration
     ) {
         Uri.Builder builder = Uri.parse(SHOW_CONNECTION_API_URL + connection.id)
             .buildUpon()
@@ -265,6 +270,10 @@ final class ButtonApiHelper {
             builder.appendQueryParameter("username", userLogin);
         } else {
             builder.appendQueryParameter("email", email);
+        }
+
+        if (skipConfiguration) {
+            builder.appendQueryParameter("skip_config", "true");
         }
 
         return builder.build();

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ButtonApiHelper.java
@@ -38,7 +38,7 @@ final class ButtonApiHelper {
     private final CredentialsProvider credentialsProvider;
     private final Lifecycle lifecycle;
     private final Uri redirectUri;
-    private final boolean skipConfiguration;
+    private final boolean skipConnectionConfiguration;
     @Nullable private final String inviteCode;
 
     @Nullable private String oAuthCode;
@@ -57,13 +57,13 @@ final class ButtonApiHelper {
         Uri redirectUri,
         @Nullable String inviteCode,
         CredentialsProvider provider,
-        Lifecycle lifecycle, boolean skipConfiguration
+        Lifecycle lifecycle, boolean skipConnectionConfiguration
     ) {
         this.lifecycle = lifecycle;
         this.redirectUri = redirectUri;
         this.inviteCode = inviteCode;
         this.connectionApiClient = client;
-        this.skipConfiguration = skipConfiguration;
+        this.skipConnectionConfiguration = skipConnectionConfiguration;
         credentialsProvider = provider;
     }
 
@@ -169,8 +169,7 @@ final class ButtonApiHelper {
             userLogin,
             anonymousId,
             oAuthCode,
-            inviteCode,
-            skipConfiguration
+            inviteCode, skipConnectionConfiguration
         );
         CustomTabsIntent intent = new CustomTabsIntent.Builder().build();
         intent.launchUrl(context, uri);
@@ -192,8 +191,7 @@ final class ButtonApiHelper {
             userLogin,
             anonymousId,
             oAuthCode,
-            inviteCode,
-            skipConfiguration
+            inviteCode, skipConnectionConfiguration
         ));
         launchIntent.setPackage(PACKAGE_NAME_IFTTT);
 
@@ -234,7 +232,7 @@ final class ButtonApiHelper {
         String anonymousId,
         @Nullable String oAuthCode,
         @Nullable String inviteCode,
-        boolean skipConfiguration
+        boolean skipConnectionConfiguration
     ) {
         Uri.Builder builder = Uri.parse(SHOW_CONNECTION_API_URL + connection.id)
             .buildUpon()
@@ -272,7 +270,7 @@ final class ButtonApiHelper {
             builder.appendQueryParameter("email", email);
         }
 
-        if (skipConfiguration) {
+        if (skipConnectionConfiguration) {
             builder.appendQueryParameter("skip_config", "true");
         }
 

--- a/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButton.java
+++ b/connect-button/src/main/java/com/ifttt/connect/ui/ConnectButton.java
@@ -138,7 +138,8 @@ public class ConnectButton extends FrameLayout implements LifecycleOwner {
             clientToUse,
             configuration.connectRedirectUri,
             configuration.credentialsProvider,
-            configuration.inviteCode
+            configuration.inviteCode,
+            configuration.skipConnectionConfiguration
         );
 
         pulseLoading();
@@ -307,6 +308,7 @@ public class ConnectButton extends FrameLayout implements LifecycleOwner {
         private final String suggestedUserEmail;
         private final CredentialsProvider credentialsProvider;
         private final Uri connectRedirectUri;
+        private final boolean skipConnectionConfiguration;
 
         @Nullable private final ConnectionApiClient connectionApiClient;
         @Nullable private String connectionId;
@@ -349,6 +351,7 @@ public class ConnectButton extends FrameLayout implements LifecycleOwner {
             @Nullable private OnFetchConnectionListener listener;
             @Nullable private Connection connection;
             @Nullable private String inviteCode;
+            private boolean skipConnectionConfiguration;
 
             private Builder(String suggestedUserEmail, Uri connectRedirectUri) {
                 this.suggestedUserEmail = suggestedUserEmail;
@@ -358,6 +361,12 @@ public class ConnectButton extends FrameLayout implements LifecycleOwner {
             @Override
             public ConfigurationSetup setOnFetchCompleteListener(OnFetchConnectionListener onFetchCompleteListener) {
                 this.listener = onFetchCompleteListener;
+                return this;
+            }
+
+            @Override
+            public ConfigurationSetup skipConnectionConfiguration() {
+                this.skipConnectionConfiguration = true;
                 return this;
             }
 
@@ -400,8 +409,7 @@ public class ConnectButton extends FrameLayout implements LifecycleOwner {
 
                 Configuration configuration = new Configuration(suggestedUserEmail,
                     credentialsProvider,
-                    connectRedirectUri,
-                    connectionApiClient
+                    connectRedirectUri, skipConnectionConfiguration, connectionApiClient
                 );
                 configuration.connection = connection;
                 configuration.connectionId = connectionId;
@@ -414,12 +422,12 @@ public class ConnectButton extends FrameLayout implements LifecycleOwner {
         private Configuration(
             String suggestedUserEmail,
             CredentialsProvider credentialsProvider,
-            Uri connectRedirectUri,
-            @Nullable ConnectionApiClient connectionApiClient
+            Uri connectRedirectUri, boolean skipConnectionConfiguration, @Nullable ConnectionApiClient connectionApiClient
         ) {
             this.suggestedUserEmail = suggestedUserEmail;
             this.credentialsProvider = credentialsProvider;
             this.connectRedirectUri = connectRedirectUri;
+            this.skipConnectionConfiguration = skipConnectionConfiguration;
             this.connectionApiClient = connectionApiClient;
         }
 
@@ -448,6 +456,17 @@ public class ConnectButton extends FrameLayout implements LifecycleOwner {
          */
         public interface ConfigurationSetup {
             ConfigurationSetup setOnFetchCompleteListener(OnFetchConnectionListener onFetchCompleteListener);
+
+            /**
+             * Set up the {@link ConnectButton} such that the Connection enable flow skips the configuration step, which
+             * is previously required for users to configure the Connection with appropriate feature field values.
+             *
+             * Setting this means that the user will have a partially enabled Connection after the enable flow is
+             * completed, and it is the developers' responsibility to update the Connection with required field values
+             * via Connect API. The partially enabled Connection will NOT be functional until all required fields are
+             * configured.
+             */
+            ConfigurationSetup skipConnectionConfiguration();
 
             Configuration build();
         }

--- a/connect-button/src/test/java/com/ifttt/connect/ui/BaseConnectButtonTest.java
+++ b/connect-button/src/test/java/com/ifttt/connect/ui/BaseConnectButtonTest.java
@@ -85,7 +85,7 @@ public final class BaseConnectButtonTest {
     public void setConnection() throws IOException {
         Connection connection = loadConnection(getClass().getClassLoader());
 
-        button.setup("a@b.com", client, Uri.parse("https://google.com"), credentialsProvider, null);
+        button.setup("a@b.com", client, Uri.parse("https://google.com"), credentialsProvider, null, false);
         button.setConnection(connection);
 
         TextSwitcher connectText = button.findViewById(R.id.connect_with_ifttt);
@@ -121,7 +121,7 @@ public final class BaseConnectButtonTest {
 
     @Test
     public void testDispatchStates() throws IOException {
-        button.setup("a@b.com", client, Uri.parse("https://google.com"), credentialsProvider, null);
+        button.setup("a@b.com", client, Uri.parse("https://google.com"), credentialsProvider, null, false);
 
         AtomicReference<ConnectButtonState> currentStateRef = new AtomicReference<>(ConnectButtonState.Initial);
         AtomicReference<ConnectButtonState> prevStateRef = new AtomicReference<>();
@@ -164,7 +164,8 @@ public final class BaseConnectButtonTest {
             TestUtils.getMockConnectionApiClient(button.getContext(), server, () -> null),
             Uri.parse("https://google.com"),
             credentialsProvider,
-            null
+            null,
+            false
         );
 
         Connection connection = loadConnection(getClass().getClassLoader());

--- a/connect-button/src/test/java/com/ifttt/connect/ui/ButtonApiHelperTest.java
+++ b/connect-button/src/test/java/com/ifttt/connect/ui/ButtonApiHelperTest.java
@@ -25,7 +25,8 @@ public final class ButtonApiHelperTest {
     @Test
     public void testRequiredFields() {
         Uri uri = ButtonApiHelper.getEmbedUri(connection, Initial, redirectUri, Collections.emptyList(), "abc@efg.com",
-                null, "", "auth_code", null);
+                null, "", "auth_code", null, false
+        );
 
         assertThat(uri.getQueryParameter("sdk_return_to")).isEqualTo("http://redirect");
         assertThat(uri.getQueryParameter("email")).isEqualTo("abc@efg.com");
@@ -35,40 +36,47 @@ public final class ButtonApiHelperTest {
     @Test
     public void testInviteCode() {
         Uri uri = ButtonApiHelper.getEmbedUri(connection, Initial, redirectUri, Collections.emptyList(), "abc@efg.com",
-                null, "", "auth_code", "abcd");
+                null, "", "auth_code", "abcd", false
+        );
         assertThat(uri.getQueryParameter("invite_code")).isEqualTo("abcd");
     }
 
     @Test
     public void testOAuthCode() {
         Uri uri = ButtonApiHelper.getEmbedUri(connection, Initial, redirectUri, Collections.emptyList(), "abc@efg.com",
-                null, "", "auth_code", "abcd");
+                null, "", "auth_code", "abcd", false
+        );
         assertThat(uri.getQueryParameter("code")).isNull();
 
         Uri uri1 = ButtonApiHelper.getEmbedUri(connection, CreateAccount, redirectUri, Collections.emptyList(),
-                "abc@efg.com", null, "", "auth_code", "abcd");
+                "abc@efg.com", null, "", "auth_code", "abcd", false
+        );
         assertThat(uri1.getQueryParameter("code")).isEqualTo("auth_code");
 
         Uri uri2 = ButtonApiHelper.getEmbedUri(connection, Login, redirectUri, Collections.emptyList(), "abc@efg.com",
-                null, "", "auth_code", "abcd");
+                null, "", "auth_code", "abcd", false
+        );
         assertThat(uri2.getQueryParameter("code")).isEqualTo("auth_code");
     }
 
     @Test
     public void testSdkCreateAccount() {
         Uri uri = ButtonApiHelper.getEmbedUri(connection, Initial, redirectUri, Collections.emptyList(), "abc@efg.com",
-                null, "", "auth_code", "abcd");
+                null, "", "auth_code", "abcd", false
+        );
         assertThat(uri.getQueryParameter("sdk_create_account")).isNull();
 
         Uri uri1 = ButtonApiHelper.getEmbedUri(connection, CreateAccount, redirectUri, Collections.emptyList(),
-                "abc@efg.com", null, "", "auth_code", "abcd");
+                "abc@efg.com", null, "", "auth_code", "abcd", false
+        );
         assertThat(uri1.getQueryParameter("sdk_create_account")).isEqualTo("true");
     }
 
     @Test
     public void testUsername() {
         Uri uri = ButtonApiHelper.getEmbedUri(connection, Initial, redirectUri, Collections.emptyList(), "abc@efg.com",
-                "user_name", "", "auth_code", "abcd");
+                "user_name", "", "auth_code", "abcd", false
+        );
         assertThat(uri.getQueryParameter("username")).isEqualTo("user_name");
         assertThat(uri.getQueryParameter("email")).isNull();
     }
@@ -76,7 +84,8 @@ public final class ButtonApiHelperTest {
     @Test
     public void testEmailAppsDetectorWhenLogin() {
         Uri uri = ButtonApiHelper.getEmbedUri(connection, Login, redirectUri, Arrays.asList("a", "b"), "abc@efg.com",
-                null, "", "auth_code", "abcd");
+                null, "", "auth_code", "abcd", false
+        );
         List<String> params = uri.getQueryParameters("available_email_app_schemes[]");
         assertThat(params).hasSize(2);
         assertThat(params.get(0)).isEqualTo("a");
@@ -86,8 +95,18 @@ public final class ButtonApiHelperTest {
     @Test
     public void testEmailAppsDetectorWhenCreateAccount() {
         Uri uri = ButtonApiHelper.getEmbedUri(connection, CreateAccount, redirectUri, Arrays.asList("a", "b"),
-                "abc@efg.com", null, "", "auth_code", "abcd");
+                "abc@efg.com", null, "", "auth_code", "abcd", false
+        );
         List<String> params = uri.getQueryParameters("available_email_app_schemes[]");
         assertThat(params).hasSize(0);
+    }
+
+    @Test
+    public void testSkipConfigurationFlag() {
+        Uri uri = ButtonApiHelper.getEmbedUri(connection, CreateAccount, redirectUri, Arrays.asList("a", "b"),
+            "abc@efg.com", null, "", "auth_code", "abcd", true
+        );
+
+        assertThat(uri.getQueryParameter("skip_config")).isEqualTo("true");
     }
 }

--- a/connect-location/build.gradle
+++ b/connect-location/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    packageBuildConfig false
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 11 06:24:01 PDT 2020
+#Thu Jun 04 15:23:22 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
Passing the flag as query parameter if developers decide to build their own configuration UI and provide field values separately via Connect API.

Using this flag will skip the connection configuration