### PR TITLE
Publish connect api as a separate artifact

### DIFF
--- a/connect-api/build.gradle
+++ b/connect-api/build.gradle
@@ -6,8 +6,8 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 6
+        versionName "$libVersion"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -43,3 +43,4 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.4.0'
     testImplementation "com.squareup.retrofit2:retrofit-mock:$retrofitVersion"
 }
+apply from: 'publish.gradle'

--- a/connect-api/publish.gradle
+++ b/connect-api/publish.gradle
@@ -6,11 +6,11 @@ ext {
     bintrayName = 'ConnectSDK-Android'
 
     publishedGroupId = 'com.ifttt'
-    libraryName = 'connect-button'
-    artifact = 'connect-button'
+    libraryName = 'connect-api'
+    artifact = 'connect-api'
 
     libraryDescription =
-            'Connect Button SDK is a library that helps facilitate the integration of the Connect Button and Connection API.'
+            'Connect Api is a library that helps facilitate network calls and data for the Connect Button SDK. It is not meant to be used as a stand-alone library'
 
     siteUrl = 'https://github.com/IFTTT/ConnectSDK-Android'
     gitUrl = 'https://github.com/IFTTT/ConnectSDK-Android.git'

--- a/connect-button/build.gradle
+++ b/connect-button/build.gradle
@@ -26,6 +26,7 @@ android {
 
 dependencies {
     api project(':connect-api')
+    releaseApi "com.ifttt:connect-api:$libVersion"
 
     implementation 'androidx.browser:browser:1.2.0'
     implementation "androidx.work:work-runtime:$workManagerVersion"


### PR DESCRIPTION
The connect-api `.aar` file could not be added to the connect-button `.aar` file so publish the former as a separate artifact within the same repo.