### PR TITLE
Move connection id param to activate

### DIFF
--- a/app/src/main/java/com/ifttt/groceryexpress/GroceryExpressApplication.kt
+++ b/app/src/main/java/com/ifttt/groceryexpress/GroceryExpressApplication.kt
@@ -10,7 +10,7 @@ class GroceryExpressApplication : Application() {
      */
     override fun onCreate() {
         super.onCreate()
-        ConnectLocation.init(this, MainActivity.CONNECTION_ID_LOCATION, GroceryExpressCredentialsProvider(EmailPreferencesHelper(this)))
+        ConnectLocation.init(this, GroceryExpressCredentialsProvider(EmailPreferencesHelper(this)))
     }
 
 }

--- a/app/src/main/java/com/ifttt/groceryexpress/MainActivity.kt
+++ b/app/src/main/java/com/ifttt/groceryexpress/MainActivity.kt
@@ -183,7 +183,7 @@ class MainActivity : AppCompatActivity() {
             Possibly show a message or any other error/warning indication for the connection not being able to work as expected
              */
         } else {
-            ConnectLocation.getInstance().activate(this, null)
+            ConnectLocation.getInstance().activate(this, CONNECTION_ID_LOCATION, null)
         }
     }
 

--- a/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
@@ -4,16 +4,28 @@ import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import androidx.annotation.NonNull;
+import androidx.work.Constraints;
+import androidx.work.Data;
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.NetworkType;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 import com.ifttt.connect.api.Connection;
 import com.ifttt.connect.api.ConnectionApiClient;
 import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import retrofit2.Response;
 
 import static androidx.core.content.ContextCompat.checkSelfPermission;
 
 public final class ConnectionRefresher extends Worker {
+
+    private static final String INPUT_DATA_CONNECTION_ID = "input_connection_id";
+    private static final String WORK_ID_CONNECTION_POLLING = "connection_refresh_polling";
+    private static final long CONNECTION_REFRESH_POLLING_INTERVAL = 1;
 
     public ConnectionRefresher(Context context, WorkerParameters params) {
         super(context, params);
@@ -25,8 +37,10 @@ public final class ConnectionRefresher extends Worker {
         ConnectionApiClient connectionApiClient = ConnectLocation.getInstance().connectionApiClient;
 
         try {
+            String connectionId = getInputData().getString(INPUT_DATA_CONNECTION_ID);
+
             Response<Connection> connectionResult = connectionApiClient.api()
-                .showConnection(ConnectLocation.getInstance().connectionId)
+                .showConnection(Objects.requireNonNull(connectionId))
                 .getCall()
                 .execute();
             if (connectionResult.isSuccessful()) {
@@ -45,5 +59,24 @@ public final class ConnectionRefresher extends Worker {
         }
 
         return Result.success();
+    }
+
+    public static void schedule(Context context, String connectionId) {
+        WorkManager workManager = WorkManager.getInstance(context);
+        Constraints constraints = new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
+        workManager.enqueueUniquePeriodicWork(WORK_ID_CONNECTION_POLLING,
+            ExistingPeriodicWorkPolicy.KEEP,
+            new PeriodicWorkRequest.Builder(ConnectionRefresher.class,
+                CONNECTION_REFRESH_POLLING_INTERVAL,
+                TimeUnit.HOURS
+            ).setConstraints(constraints)
+                .setInputData(new Data.Builder().putString(INPUT_DATA_CONNECTION_ID, connectionId).build())
+                .build()
+        );
+    }
+
+    public static void cancel(Context context) {
+        WorkManager workManager = WorkManager.getInstance(context);
+        workManager.cancelUniqueWork(WORK_ID_CONNECTION_POLLING);
     }
 }

--- a/connect-location/src/main/java/com/ifttt/location/LocationEventUploader.java
+++ b/connect-location/src/main/java/com/ifttt/location/LocationEventUploader.java
@@ -64,7 +64,7 @@ public final class LocationEventUploader extends Worker {
             if (!uploadResponse.isSuccessful()) {
                 if (uploadResponse.code() == 401) {
                     // The token is invalid, unregister all geo-fences and return.
-                    location.deactivate();
+                    location.deactivate(getApplicationContext());
                     return Result.failure();
                 }
 

--- a/connect-location/src/test/java/com/ifttt/location/ConnectLocationTest.java
+++ b/connect-location/src/test/java/com/ifttt/location/ConnectLocationTest.java
@@ -7,7 +7,6 @@ import android.net.Uri;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.work.WorkManager;
 import com.ifttt.connect.api.Connection;
 import com.ifttt.connect.api.ConnectionApiClient;
 import com.ifttt.connect.api.Feature;
@@ -40,18 +39,15 @@ public class ConnectLocationTest {
 
     private ConnectButton button;
     private ConnectionApiClient apiClient;
-    private CredentialsProvider credentialsProvider;
-    private WorkManager workManager;
 
     @Before
     public void setUp() {
         ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class);
         scenario.onActivity(activity -> {
             button = new ConnectButton(activity);
-            workManager = WorkManager.getInstance(activity);
         });
 
-        credentialsProvider = new CredentialsProvider() {
+        CredentialsProvider credentialsProvider = new CredentialsProvider() {
             @Override
             public String getOAuthCode() {
                 return null;
@@ -77,12 +73,12 @@ public class ConnectLocationTest {
         Connection connection = connection(Connection.Status.enabled);
 
         AtomicBoolean ref = new AtomicBoolean();
-        ConnectLocation location = new ConnectLocation("id", new GeofenceProviderAdapter() {
+        ConnectLocation location = new ConnectLocation(new GeofenceProviderAdapter() {
             @Override
             public void updateGeofences(Connection connection) {
                 fail();
             }
-        }, apiClient, workManager);
+        }, apiClient);
         location.setUpWithConnectButton(button, () -> ref.set(true));
         button.setup(ConnectButton.Configuration.newBuilder("email@ifttt.com", Uri.EMPTY)
             .withConnection(connection)
@@ -110,12 +106,12 @@ public class ConnectLocationTest {
         Connection connection = connection(Connection.Status.enabled);
 
         AtomicBoolean ref = new AtomicBoolean();
-        ConnectLocation location = new ConnectLocation("id", new GeofenceProviderAdapter() {
+        ConnectLocation location = new ConnectLocation(new GeofenceProviderAdapter() {
             @Override
             public void updateGeofences(Connection connection) {
                 ref.set(true);
             }
-        }, apiClient, workManager);
+        }, apiClient);
         location.setUpWithConnectButton(button, Assert::fail);
         button.setup(ConnectButton.Configuration.newBuilder("email@ifttt.com", Uri.EMPTY)
             .withConnection(connection)
@@ -143,12 +139,12 @@ public class ConnectLocationTest {
         Connection connection = connection(Connection.Status.disabled);
 
         AtomicBoolean ref = new AtomicBoolean();
-        ConnectLocation location = new ConnectLocation("id", new GeofenceProviderAdapter() {
+        ConnectLocation location = new ConnectLocation(new GeofenceProviderAdapter() {
             @Override
-            public void updateGeofences(Connection connection) {
+            public void removeGeofences() {
                 ref.set(true);
             }
-        }, apiClient, workManager);
+        }, apiClient);
         location.setUpWithConnectButton(button, Assert::fail);
         button.setup(ConnectButton.Configuration.newBuilder("email@ifttt.com", Uri.EMPTY)
             .withConnection(connection)
@@ -176,12 +172,12 @@ public class ConnectLocationTest {
         Connection connection = connection(Connection.Status.never_enabled);
 
         AtomicBoolean ref = new AtomicBoolean();
-        ConnectLocation location = new ConnectLocation("id", new GeofenceProviderAdapter() {
+        ConnectLocation location = new ConnectLocation(new GeofenceProviderAdapter() {
             @Override
-            public void updateGeofences(Connection connection) {
+            public void removeGeofences() {
                 ref.set(true);
             }
-        }, apiClient, workManager);
+        }, apiClient);
         location.setUpWithConnectButton(button, Assert::fail);
         button.setup(ConnectButton.Configuration.newBuilder("email@ifttt.com", Uri.EMPTY)
             .withConnection(connection)
@@ -236,7 +232,7 @@ public class ConnectLocationTest {
         );
     }
 
-    private abstract class GeofenceProviderAdapter implements GeofenceProvider {
+    private abstract static class GeofenceProviderAdapter implements GeofenceProvider {
         @Override
         public void updateGeofences(Connection connection) {
             throw new UnsupportedOperationException();


### PR DESCRIPTION
This is to make sure the ConnectLocation.init() can be called without having to tie to certain connection.

Once initialized, the ConnectLocation#activate needs to provide the connection id, in order to set up the background polling worker.