### PR TITLE
Listen to reboot broadcast and refresh connection

### DIFF
--- a/connect-location/src/main/AndroidManifest.xml
+++ b/connect-location/src/main/AndroidManifest.xml
@@ -3,9 +3,15 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application>
         <receiver android:name=".AwarenessEnterReceiver" />
         <receiver android:name=".AwarenessExitReceiver" />
+        <receiver android:name=".RebootBroadcastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
@@ -122,7 +122,7 @@ public final class ConnectionRefresher extends Worker {
     @VisibleForTesting
     @Nullable
     static UUID scheduleOneTimeRefreshWork(WorkManager workManager, List<WorkInfo> workInfoList) {
-        if (workInfoList.size() == 1) {
+        if (workInfoList.size() == 1 && workInfoList.get(0).getState() != WorkInfo.State.CANCELLED) {
             List<String> tags = new ArrayList<>(workInfoList.get(0).getTags());
             for (String tag : tags) {
                 Logger.log("Tag: " + tag);

--- a/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
@@ -3,20 +3,29 @@ package com.ifttt.location;
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.work.Constraints;
 import androidx.work.Data;
 import androidx.work.ExistingPeriodicWorkPolicy;
 import androidx.work.NetworkType;
+import androidx.work.OneTimeWorkRequest;
 import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.ifttt.connect.api.Connection;
 import com.ifttt.connect.api.ConnectionApiClient;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import retrofit2.Response;
 
@@ -25,8 +34,9 @@ import static androidx.core.content.ContextCompat.checkSelfPermission;
 public final class ConnectionRefresher extends Worker {
 
     private static final String INPUT_DATA_CONNECTION_ID = "input_connection_id";
-    private static final String WORK_ID_CONNECTION_POLLING = "connection_refresh_polling";
     private static final long CONNECTION_REFRESH_POLLING_INTERVAL = 1;
+
+    @VisibleForTesting static final String WORK_ID_CONNECTION_POLLING = "connection_refresh_polling";
 
     public ConnectionRefresher(Context context, WorkerParameters params) {
         super(context, params);
@@ -40,22 +50,22 @@ public final class ConnectionRefresher extends Worker {
         try {
             String connectionId = getInputData().getString(INPUT_DATA_CONNECTION_ID);
 
-            Response<Connection> connectionResult = connectionApiClient.api()
-                .showConnection(Objects.requireNonNull(connectionId))
-                .getCall()
-                .execute();
+            Response<Connection> connectionResult = connectionApiClient.api().showConnection(Objects.requireNonNull(
+                connectionId)).getCall().execute();
             if (connectionResult.isSuccessful()) {
                 Connection connection = connectionResult.body();
                 if (connection == null) {
-                    Logger.error("Connection cannot be null");
                     throw new IllegalStateException("Connection cannot be null");
                 }
 
-                Logger.log("Connection fetch successful");
+                Logger.log("Connection fetch successful: " + connectionId);
                 if (checkSelfPermission(getApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION)
                     == PackageManager.PERMISSION_GRANTED) {
                     ConnectLocation.getInstance().geofenceProvider.updateGeofences(connection, null);
                 }
+            } else {
+                Logger.error("Could not fetch connection: " + connectionId);
+                return Result.failure();
             }
         } catch (IOException e) {
             Logger.error("Connection fetch failed with an IOException");
@@ -65,24 +75,79 @@ public final class ConnectionRefresher extends Worker {
         return Result.success();
     }
 
-    public static void schedule(Context context, String connectionId) {
+    static void schedule(Context context, String connectionId) {
         Logger.log("Schedule connection polling");
         WorkManager workManager = WorkManager.getInstance(context);
-        Constraints constraints = new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
         workManager.enqueueUniquePeriodicWork(WORK_ID_CONNECTION_POLLING,
             ExistingPeriodicWorkPolicy.KEEP,
             new PeriodicWorkRequest.Builder(ConnectionRefresher.class,
                 CONNECTION_REFRESH_POLLING_INTERVAL,
                 TimeUnit.HOURS
-            ).setConstraints(constraints)
-                .setInputData(new Data.Builder().putString(INPUT_DATA_CONNECTION_ID, connectionId).build())
+            ).addTag("connection_id:"
+                + connectionId)
+                .setConstraints(networkConstraint())
+                .setInputData(connectionIdData(connectionId))
                 .build()
         );
     }
 
-    public static void cancel(Context context) {
+    static void executeIfExists(Context context) {
+        Logger.log("Checking periodic connection refresh job");
+
+        WorkManager workManager = WorkManager.getInstance(context);
+        ListenableFuture<List<WorkInfo>> future = workManager.getWorkInfosForUniqueWork(WORK_ID_CONNECTION_POLLING);
+        future.addListener(() -> {
+            try {
+                List<WorkInfo> workInfoList = future.get();
+                // If the refresher job is scheduled, we should only have one WorkInfo.
+                scheduleOneTimeRefreshWork(workManager, workInfoList);
+            } catch (ExecutionException e) {
+                if (BuildConfig.DEBUG) {
+                    e.printStackTrace();
+                }
+            } catch (InterruptedException e) {
+                if (BuildConfig.DEBUG) {
+                    e.printStackTrace();
+                }
+            }
+        }, Executors.newSingleThreadExecutor());
+    }
+
+    static void cancel(Context context) {
         Logger.log("Cancel connection polling");
         WorkManager workManager = WorkManager.getInstance(context);
         workManager.cancelUniqueWork(WORK_ID_CONNECTION_POLLING);
+    }
+
+    @VisibleForTesting
+    @Nullable
+    static UUID scheduleOneTimeRefreshWork(WorkManager workManager, List<WorkInfo> workInfoList) {
+        if (workInfoList.size() == 1) {
+            List<String> tags = new ArrayList<>(workInfoList.get(0).getTags());
+            for (String tag : tags) {
+                Logger.log("Tag: " + tag);
+                if (!tag.startsWith("connection_id:")) {
+                    continue;
+                }
+
+                String connectionId = tag.substring(14);
+                Logger.log("Execute connection refresh job: " + connectionId);
+                OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(ConnectionRefresher.class).setConstraints(
+                    networkConstraint()).setInputData(connectionIdData(connectionId)).build();
+                workManager.enqueue(request);
+
+                return request.getId();
+            }
+        }
+
+        return null;
+    }
+
+    private static Constraints networkConstraint() {
+        return new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
+    }
+
+    private static Data connectionIdData(String connectionId) {
+        return new Data.Builder().putString(INPUT_DATA_CONNECTION_ID, connectionId).build();
     }
 }

--- a/connect-location/src/main/java/com/ifttt/location/RebootBroadcastReceiver.java
+++ b/connect-location/src/main/java/com/ifttt/location/RebootBroadcastReceiver.java
@@ -1,0 +1,21 @@
+package com.ifttt.location;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * A {@link BroadcastReceiver} that listens to system's {@link Intent#ACTION_BOOT_COMPLETED} broadcast, and make an
+ * attempt to re-register geo-fences.
+ */
+public final class RebootBroadcastReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (!intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
+            return;
+        }
+
+        ConnectionRefresher.executeIfExists(context);
+    }
+}

--- a/connect-location/src/test/java/com/ifttt/location/ConnectionRefresherTest.java
+++ b/connect-location/src/test/java/com/ifttt/location/ConnectionRefresherTest.java
@@ -1,0 +1,64 @@
+package com.ifttt.location;
+
+import android.content.Context;
+import android.util.Log;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.work.Configuration;
+import androidx.work.WorkInfo;
+import androidx.work.WorkManager;
+import androidx.work.testing.SynchronousExecutor;
+import androidx.work.testing.WorkManagerTestInitHelper;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public final class ConnectionRefresherTest {
+
+    private Context context;
+
+    @Before
+    public void setUp() throws Exception {
+        context = InstrumentationRegistry.getInstrumentation().getContext();
+        Configuration config = new Configuration.Builder().setMinimumLoggingLevel(Log.DEBUG)
+            .setExecutor(new SynchronousExecutor())
+            .build();
+
+        // Initialize WorkManager for instrumentation tests.
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config);
+    }
+
+    @Test
+    public void shouldAddTagToPeriodicJob() throws ExecutionException, InterruptedException {
+        ConnectionRefresher.schedule(context, "ConnectionID");
+
+        WorkManager workManager = WorkManager.getInstance(context);
+        List<WorkInfo> infoList = workManager.getWorkInfosForUniqueWork(ConnectionRefresher.WORK_ID_CONNECTION_POLLING)
+            .get();
+
+        assertThat(infoList).hasSize(1);
+        assertThat(infoList.get(0).getState()).isEqualTo(WorkInfo.State.ENQUEUED);
+        assertThat(infoList.get(0).getTags()).contains("connection_id:ConnectionID");
+    }
+
+    @Test
+    public void shouldScheduleExecuteJobIfPeriodicIsScheduled() throws ExecutionException, InterruptedException {
+        WorkManager workManager = WorkManager.getInstance(context);
+
+        ConnectionRefresher.schedule(context, "ConnectionID");
+        List<WorkInfo> infoList = workManager.getWorkInfosForUniqueWork(ConnectionRefresher.WORK_ID_CONNECTION_POLLING)
+            .get();
+
+        UUID id = ConnectionRefresher.scheduleOneTimeRefreshWork(workManager, infoList);
+        assertThat(id).isNotNull();
+
+        WorkInfo info = workManager.getWorkInfoById(id).get();
+        assertThat(info.getState()).isEqualTo(WorkInfo.State.ENQUEUED);
+    }
+}


### PR DESCRIPTION
Looks like Awareness API doesn't handle geofences re-registration after a device reboot.

To make sure host apps don't have to handle this, we can reuse the ConnectionRefresher (renamed to ConnectionRefreshWorker) that's scheduled to retrieve connection id data, and then enqueue a one time job immediately, to try to re-register all active geofences.

If the ConnectionRefreshWorker is not scheduled, the BroadcastReceiver will be no-op.