### PR TITLE
Only monitor fences registered within SDK

### DIFF
--- a/connect-location/src/main/java/com/ifttt/location/LocationEventUploadHelper.java
+++ b/connect-location/src/main/java/com/ifttt/location/LocationEventUploadHelper.java
@@ -19,6 +19,7 @@ final class LocationEventUploadHelper {
 
     private static final String SHARED_PREFERENCES_CONNECT_LOCATION = "ifttt_connection_location";
     private static final String PREFERENCES_KEY_INSTALLATION_ID = "ifttt_connection_location.installation_id";
+    private static final String IFTTT_FENCE_KEY_PREFIX = "ifttt_";
 
     static String getInstallationId(Context context) {
         SharedPreferences preferences = context.getSharedPreferences(SHARED_PREFERENCES_CONNECT_LOCATION,
@@ -72,6 +73,14 @@ final class LocationEventUploadHelper {
         return results;
     }
 
+    static boolean isIftttFenceKey(String id) {
+        return id.startsWith(IFTTT_FENCE_KEY_PREFIX);
+    }
+
+    static String getIftttFenceKey(String id) {
+        return IFTTT_FENCE_KEY_PREFIX.concat(id);
+    }
+
     static String getEnterFenceKey(String id) {
         return id.concat("/enter");
     }
@@ -81,12 +90,19 @@ final class LocationEventUploadHelper {
     }
 
     static String extractStepId(String fenceKey) {
-        int dividerIndex = fenceKey.indexOf("/");
-        if (dividerIndex < 0) {
-            return fenceKey;
+        String stepId;
+        if (fenceKey.startsWith(IFTTT_FENCE_KEY_PREFIX)) {
+            stepId = fenceKey.substring(6);
+        } else {
+            stepId = fenceKey;
         }
 
-        return fenceKey.substring(0, dividerIndex);
+        int dividerIndex = stepId.indexOf("/");
+        if (dividerIndex < 0) {
+            return stepId;
+        }
+
+        return stepId.substring(0, dividerIndex);
     }
 
     private LocationEventUploadHelper() {

--- a/connect-location/src/test/java/com/ifttt/location/AwarenessGeofenceProviderTest.java
+++ b/connect-location/src/test/java/com/ifttt/location/AwarenessGeofenceProviderTest.java
@@ -60,7 +60,7 @@ public final class AwarenessGeofenceProviderTest {
                 public void onAddFence(
                     String key, AwarenessFence value, PendingIntent pendingIntent
                 ) {
-                    assertThat(key).isEqualTo("step_id");
+                    assertThat(key).isEqualTo("ifttt_step_id");
                     assertThat(pendingIntent).isEqualTo(enter);
                 }
 
@@ -93,7 +93,7 @@ public final class AwarenessGeofenceProviderTest {
                 public void onAddFence(
                     String key, AwarenessFence value, PendingIntent pendingIntent
                 ) {
-                    assertThat(key).isEqualTo("step_id");
+                    assertThat(key).isEqualTo("ifttt_step_id");
                     assertThat(pendingIntent).isEqualTo(exit);
                 }
 
@@ -139,8 +139,8 @@ public final class AwarenessGeofenceProviderTest {
             }
         );
 
-        assertThat(keysRef.get().get(0)).isEqualTo("step_id/enter");
-        assertThat(keysRef.get().get(1)).isEqualTo("step_id/exit");
+        assertThat(keysRef.get().get(0)).isEqualTo("ifttt_step_id/enter");
+        assertThat(keysRef.get().get(1)).isEqualTo("ifttt_step_id/exit");
         assertThat(pendingIntentRef.get().get(0)).isEqualTo(enter);
         assertThat(pendingIntentRef.get().get(1)).isEqualTo(exit);
     }
@@ -150,7 +150,7 @@ public final class AwarenessGeofenceProviderTest {
         AwarenessGeofenceProvider.diffFences(
             Connection.Status.enabled,
             ImmutableList.of(feature),
-            ImmutableSet.of("step_id"),
+            ImmutableSet.of("ifttt_step_id"),
             enter,
             exit,
             new AwarenessGeofenceProvider.DiffCallback() {

--- a/connect-location/src/test/java/com/ifttt/location/LocationEventUploadHelperTest.java
+++ b/connect-location/src/test/java/com/ifttt/location/LocationEventUploadHelperTest.java
@@ -19,6 +19,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.ifttt.location.LocationEventUploadHelper.extractStepId;
+import static com.ifttt.location.LocationEventUploadHelper.getEnterFenceKey;
+import static com.ifttt.location.LocationEventUploadHelper.getIftttFenceKey;
 
 @RunWith(AndroidJUnit4.class)
 public final class LocationEventUploadHelperTest {
@@ -73,6 +76,18 @@ public final class LocationEventUploadHelperTest {
         assertThat(result.get("user_feature_step_id").get(0).value).isEqualTo(value);
     }
 
+    @Test
+    public void shouldRemoveSuffix() {
+        String fenceKey = getEnterFenceKey("step_id");
+        assertThat(extractStepId(fenceKey)).isEqualTo("step_id");
+    }
+
+    @Test
+    public void shouldRemovePrefix() {
+        String fenceKey = getIftttFenceKey("step_id");
+        assertThat(extractStepId(fenceKey)).isEqualTo("step_id");
+    }
+
     private List<Feature> features(
         boolean hasUserFeature,
         boolean hasEnabledUserFeature,
@@ -110,8 +125,8 @@ public final class LocationEventUploadHelperTest {
     @Test
     public void shouldExtractStepIdFromEncodedValue() {
         String stepId = "step_id";
-        String entryEncoded = LocationEventUploadHelper.getEnterFenceKey(stepId);
-        String exitEncoded = LocationEventUploadHelper.getEnterFenceKey(stepId);
+        String entryEncoded = getEnterFenceKey(stepId);
+        String exitEncoded = getEnterFenceKey(stepId);
 
         assertThat(LocationEventUploadHelper.extractStepId(entryEncoded)).isEqualTo(stepId);
         assertThat(LocationEventUploadHelper.extractStepId(exitEncoded)).isEqualTo(stepId);


### PR DESCRIPTION
So that we don't affect fences registered by the host app.