### PR TITLE
Always register geofences in activate

### DIFF
--- a/connect-location/src/main/java/com/ifttt/location/AwarenessGeofenceProvider.java
+++ b/connect-location/src/main/java/com/ifttt/location/AwarenessGeofenceProvider.java
@@ -157,45 +157,33 @@ final class AwarenessGeofenceProvider implements GeofenceProvider {
                 LocationFieldValue region = userFeatureField.value;
                 switch (userFeatureField.fieldType) {
                     case FIELD_TYPE_LOCATION_ENTER:
-                        if (!fenceKeysToRemove.contains(id)) {
-                            callback.onAddFence(id,
-                                LocationFence.entering(region.lat, region.lng, region.radius),
-                                enterPendingIntent
-                            );
-                        } else {
-                            fenceKeysToRemove.remove(id);
-                        }
+                        callback.onAddFence(id,
+                            LocationFence.entering(region.lat, region.lng, region.radius),
+                            enterPendingIntent
+                        );
+                        fenceKeysToRemove.remove(id);
                         break;
                     case FIELD_TYPE_LOCATION_EXIT:
-                        if (!fenceKeysToRemove.contains(id)) {
-                            callback.onAddFence(id,
-                                LocationFence.exiting(region.lat, region.lng, region.radius),
-                                exitPendingIntent
-                            );
-                        } else {
-                            fenceKeysToRemove.remove(id);
-                        }
+                        callback.onAddFence(id,
+                            LocationFence.exiting(region.lat, region.lng, region.radius),
+                            exitPendingIntent
+                        );
+                        fenceKeysToRemove.remove(id);
                         break;
                     case FIELD_TYPE_LOCATION_ENTER_EXIT:
                         String enterFenceKey = getEnterFenceKey(id);
-                        if (!fenceKeysToRemove.contains(enterFenceKey)) {
-                            callback.onAddFence(enterFenceKey,
-                                LocationFence.entering(region.lat, region.lng, region.radius),
-                                enterPendingIntent
-                            );
-                        } else {
-                            fenceKeysToRemove.remove(enterFenceKey);
-                        }
+                        callback.onAddFence(enterFenceKey,
+                            LocationFence.entering(region.lat, region.lng, region.radius),
+                            enterPendingIntent
+                        );
+                        fenceKeysToRemove.remove(enterFenceKey);
 
                         String exitFenceKey = getExitFenceKey(id);
-                        if (!fenceKeysToRemove.contains(exitFenceKey)) {
-                            callback.onAddFence(exitFenceKey,
-                                LocationFence.exiting(region.lat, region.lng, region.radius),
-                                exitPendingIntent
-                            );
-                        } else {
-                            fenceKeysToRemove.remove(exitFenceKey);
-                        }
+                        callback.onAddFence(exitFenceKey,
+                            LocationFence.exiting(region.lat, region.lng, region.radius),
+                            exitPendingIntent
+                        );
+                        fenceKeysToRemove.remove(exitFenceKey);
                         break;
                     default:
                         // No-op for other location types.

--- a/connect-location/src/test/java/com/ifttt/location/AwarenessGeofenceProviderTest.java
+++ b/connect-location/src/test/java/com/ifttt/location/AwarenessGeofenceProviderTest.java
@@ -146,7 +146,8 @@ public final class AwarenessGeofenceProviderTest {
     }
 
     @Test
-    public void shouldNotRegisterExistingGeofences() {
+    public void shouldReplaceExistingGeofences() {
+        AtomicReference<String> ref = new AtomicReference<>();
         AwarenessGeofenceProvider.diffFences(
             Connection.Status.enabled,
             ImmutableList.of(feature),
@@ -158,7 +159,7 @@ public final class AwarenessGeofenceProviderTest {
                 public void onAddFence(
                     String key, AwarenessFence value, PendingIntent pendingIntent
                 ) {
-                    fail();
+                    ref.set(key);
                 }
 
                 @Override
@@ -167,6 +168,8 @@ public final class AwarenessGeofenceProviderTest {
                 }
             }
         );
+
+        assertThat(ref.get()).isEqualTo("step_id");
     }
 
     @Test

--- a/connect-location/src/test/java/com/ifttt/location/AwarenessGeofenceProviderTest.java
+++ b/connect-location/src/test/java/com/ifttt/location/AwarenessGeofenceProviderTest.java
@@ -169,7 +169,7 @@ public final class AwarenessGeofenceProviderTest {
             }
         );
 
-        assertThat(ref.get()).isEqualTo("step_id");
+        assertThat(ref.get()).isEqualTo("ifttt_step_id");
     }
 
     @Test


### PR DESCRIPTION
So that we can replace fences from previously installed but now uninstalled apps. Reports were saying the old fences were still registered after re-installing the app, but the fences don't actually trigger.