### PR TITLE
Cache user token for ConnectLocation

### DIFF
--- a/connect-api/src/main/java/com/ifttt/connect/api/UserTokenProvider.java
+++ b/connect-api/src/main/java/com/ifttt/connect/api/UserTokenProvider.java
@@ -1,5 +1,6 @@
 package com.ifttt.connect.api;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 public interface UserTokenProvider {
@@ -9,6 +10,7 @@ public interface UserTokenProvider {
      * method is potentially going to be called for every API call, we recommend caching this value if possible to avoid
      * unnecessary operations.
      */
+    @Nullable
     @WorkerThread
     String getUserToken();
 }

--- a/connect-location/src/main/AndroidManifest.xml
+++ b/connect-location/src/main/AndroidManifest.xml
@@ -3,9 +3,15 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application>
         <receiver android:name=".AwarenessEnterReceiver" />
         <receiver android:name=".AwarenessExitReceiver" />
+        <receiver android:name=".RebootBroadcastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/connect-location/src/main/java/com/ifttt/location/CacheUserTokenProvider.java
+++ b/connect-location/src/main/java/com/ifttt/location/CacheUserTokenProvider.java
@@ -19,7 +19,9 @@ class CacheUserTokenProvider implements UserTokenProvider {
         String token;
         if (delegate != null) {
             token = delegate.getUserToken();
-            cache.store(token);
+            if (token != null) {
+                cache.store(token);
+            }
         } else {
             token = cache.get();
         }

--- a/connect-location/src/main/java/com/ifttt/location/CacheUserTokenProvider.java
+++ b/connect-location/src/main/java/com/ifttt/location/CacheUserTokenProvider.java
@@ -1,0 +1,29 @@
+package com.ifttt.location;
+
+import androidx.annotation.Nullable;
+import com.ifttt.connect.api.UserTokenProvider;
+
+class CacheUserTokenProvider implements UserTokenProvider {
+
+    private final UserTokenCache cache;
+    @Nullable private final UserTokenProvider delegate;
+
+    CacheUserTokenProvider(UserTokenCache cache, @Nullable UserTokenProvider delegate) {
+        this.cache = cache;
+        this.delegate = delegate;
+    }
+
+    @Nullable
+    @Override
+    public String getUserToken() {
+        String token;
+        if (delegate != null) {
+            token = delegate.getUserToken();
+            cache.store(token);
+        } else {
+            token = cache.get();
+        }
+
+        return token;
+    }
+}

--- a/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
@@ -52,17 +52,22 @@ public final class ConnectLocation {
     final ConnectionApiClient connectionApiClient;
 
     public static synchronized ConnectLocation init(Context context, ConnectionApiClient apiClient) {
-        if (INSTANCE == null) {
-            INSTANCE = new ConnectLocation(new AwarenessGeofenceProvider(context.getApplicationContext()), apiClient);
-        }
+        INSTANCE = new ConnectLocation(new AwarenessGeofenceProvider(context.getApplicationContext()), apiClient);
         return INSTANCE;
     }
 
-    public static synchronized ConnectLocation init(
-        Context context, @Nullable UserTokenProvider userTokenProvider
-    ) {
+    public static synchronized ConnectLocation init(Context context, UserTokenProvider userTokenProvider) {
         ConnectionApiClient client = new ConnectionApiClient.Builder(context,
             new CacheUserTokenProvider(new UserTokenCache(context), userTokenProvider)
+        ).build();
+        INSTANCE = new ConnectLocation(new AwarenessGeofenceProvider(context.getApplicationContext()), client);
+
+        return INSTANCE;
+    }
+
+    public static synchronized ConnectLocation init(Context context) {
+        ConnectionApiClient client = new ConnectionApiClient.Builder(context,
+            new CacheUserTokenProvider(new UserTokenCache(context), null)
         ).build();
         INSTANCE = new ConnectLocation(new AwarenessGeofenceProvider(context.getApplicationContext()), client);
 
@@ -76,6 +81,10 @@ public final class ConnectLocation {
         }
 
         return INSTANCE;
+    }
+
+    static boolean isInitialized() {
+        return INSTANCE != null;
     }
 
     /**

--- a/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
@@ -91,6 +91,9 @@ public final class ConnectLocation {
             public void onStateChanged(
                 ConnectButtonState currentState, ConnectButtonState previousState, Connection connection
             ) {
+                // Set up polling job for fetching the latest connection data.
+                ConnectionRefresher.schedule(connectButton.getContext(), connection.id);
+
                 if (currentState == ConnectButtonState.Enabled) {
                     doActivate(connectButton.getContext(), connection, permissionCallback);
                 } else if (currentState == ConnectButtonState.Disabled || currentState == ConnectButtonState.Initial) {

--- a/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
@@ -17,6 +17,8 @@ import com.ifttt.connect.ui.ConnectButton;
 import com.ifttt.connect.ui.ConnectButtonState;
 
 import static androidx.core.content.ContextCompat.checkSelfPermission;
+import static com.ifttt.connect.ui.ConnectButtonState.Disabled;
+import static com.ifttt.connect.ui.ConnectButtonState.Enabled;
 
 /**
  * The main class for the Connect Location SDK. This class handles state change events from {@link ConnectButton},
@@ -91,12 +93,13 @@ public final class ConnectLocation {
             public void onStateChanged(
                 ConnectButtonState currentState, ConnectButtonState previousState, Connection connection
             ) {
-                // Set up polling job for fetching the latest connection data.
-                ConnectionRefresher.schedule(connectButton.getContext(), connection.id);
+                if (currentState == Enabled || currentState == Disabled) {
+                    ConnectionRefresher.schedule(connectButton.getContext(), connection.id);
+                }
 
-                if (currentState == ConnectButtonState.Enabled) {
+                if (currentState == Enabled) {
                     doActivate(connectButton.getContext(), connection, permissionCallback);
-                } else if (currentState == ConnectButtonState.Disabled || currentState == ConnectButtonState.Initial) {
+                } else if (currentState == Disabled || currentState == ConnectButtonState.Initial) {
                     deactivate(connectButton.getContext(), permissionCallback);
                 }
             }

--- a/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
@@ -45,6 +45,10 @@ public final class ConnectionRefresher extends Worker {
     @Override
     @NonNull
     public Result doWork() {
+        if (!ConnectLocation.isInitialized()) {
+            ConnectLocation.init(getApplicationContext());
+        }
+
         ConnectionApiClient connectionApiClient = ConnectLocation.getInstance().connectionApiClient;
 
         try {

--- a/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
@@ -4,18 +4,28 @@ import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.work.Constraints;
 import androidx.work.Data;
 import androidx.work.ExistingPeriodicWorkPolicy;
 import androidx.work.NetworkType;
+import androidx.work.OneTimeWorkRequest;
 import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.ifttt.connect.api.Connection;
 import com.ifttt.connect.api.ConnectionApiClient;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import retrofit2.Response;
 
@@ -24,8 +34,9 @@ import static androidx.core.content.ContextCompat.checkSelfPermission;
 public final class ConnectionRefresher extends Worker {
 
     private static final String INPUT_DATA_CONNECTION_ID = "input_connection_id";
-    private static final String WORK_ID_CONNECTION_POLLING = "connection_refresh_polling";
     private static final long CONNECTION_REFRESH_POLLING_INTERVAL = 1;
+
+    @VisibleForTesting static final String WORK_ID_CONNECTION_POLLING = "connection_refresh_polling";
 
     public ConnectionRefresher(Context context, WorkerParameters params) {
         super(context, params);
@@ -39,22 +50,22 @@ public final class ConnectionRefresher extends Worker {
         try {
             String connectionId = getInputData().getString(INPUT_DATA_CONNECTION_ID);
 
-            Response<Connection> connectionResult = connectionApiClient.api()
-                .showConnection(Objects.requireNonNull(connectionId))
-                .getCall()
-                .execute();
+            Response<Connection> connectionResult = connectionApiClient.api().showConnection(Objects.requireNonNull(
+                connectionId)).getCall().execute();
             if (connectionResult.isSuccessful()) {
                 Connection connection = connectionResult.body();
                 if (connection == null) {
-                    Logger.error("Connection cannot be null");
                     throw new IllegalStateException("Connection cannot be null");
                 }
 
-                Logger.log("Connection fetch successful");
+                Logger.log("Connection fetch successful: " + connectionId);
                 if (checkSelfPermission(getApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION)
                     == PackageManager.PERMISSION_GRANTED) {
                     ConnectLocation.getInstance().geofenceProvider.updateGeofences(connection, null);
                 }
+            } else {
+                Logger.error("Could not fetch connection: " + connectionId);
+                return Result.failure();
             }
         } catch (IOException e) {
             Logger.error("Connection fetch failed with an IOException");
@@ -64,24 +75,79 @@ public final class ConnectionRefresher extends Worker {
         return Result.success();
     }
 
-    public static void schedule(Context context, String connectionId) {
+    static void schedule(Context context, String connectionId) {
         Logger.log("Schedule connection polling");
         WorkManager workManager = WorkManager.getInstance(context);
-        Constraints constraints = new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
         workManager.enqueueUniquePeriodicWork(WORK_ID_CONNECTION_POLLING,
             ExistingPeriodicWorkPolicy.KEEP,
             new PeriodicWorkRequest.Builder(ConnectionRefresher.class,
                 CONNECTION_REFRESH_POLLING_INTERVAL,
                 TimeUnit.HOURS
-            ).setConstraints(constraints)
-                .setInputData(new Data.Builder().putString(INPUT_DATA_CONNECTION_ID, connectionId).build())
+            ).addTag("connection_id:"
+                + connectionId)
+                .setConstraints(networkConstraint())
+                .setInputData(connectionIdData(connectionId))
                 .build()
         );
     }
 
-    public static void cancel(Context context) {
+    static void executeIfExists(Context context) {
+        Logger.log("Checking periodic connection refresh job");
+
+        WorkManager workManager = WorkManager.getInstance(context);
+        ListenableFuture<List<WorkInfo>> future = workManager.getWorkInfosForUniqueWork(WORK_ID_CONNECTION_POLLING);
+        future.addListener(() -> {
+            try {
+                List<WorkInfo> workInfoList = future.get();
+                // If the refresher job is scheduled, we should only have one WorkInfo.
+                scheduleOneTimeRefreshWork(workManager, workInfoList);
+            } catch (ExecutionException e) {
+                if (BuildConfig.DEBUG) {
+                    e.printStackTrace();
+                }
+            } catch (InterruptedException e) {
+                if (BuildConfig.DEBUG) {
+                    e.printStackTrace();
+                }
+            }
+        }, Executors.newSingleThreadExecutor());
+    }
+
+    static void cancel(Context context) {
         Logger.log("Cancel connection polling");
         WorkManager workManager = WorkManager.getInstance(context);
         workManager.cancelUniqueWork(WORK_ID_CONNECTION_POLLING);
+    }
+
+    @VisibleForTesting
+    @Nullable
+    static UUID scheduleOneTimeRefreshWork(WorkManager workManager, List<WorkInfo> workInfoList) {
+        if (workInfoList.size() == 1 && workInfoList.get(0).getState() != WorkInfo.State.CANCELLED) {
+            List<String> tags = new ArrayList<>(workInfoList.get(0).getTags());
+            for (String tag : tags) {
+                Logger.log("Tag: " + tag);
+                if (!tag.startsWith("connection_id:")) {
+                    continue;
+                }
+
+                String connectionId = tag.substring(14);
+                Logger.log("Execute connection refresh job: " + connectionId);
+                OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(ConnectionRefresher.class).setConstraints(
+                    networkConstraint()).setInputData(connectionIdData(connectionId)).build();
+                workManager.enqueue(request);
+
+                return request.getId();
+            }
+        }
+
+        return null;
+    }
+
+    private static Constraints networkConstraint() {
+        return new Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build();
+    }
+
+    private static Data connectionIdData(String connectionId) {
+        return new Data.Builder().putString(INPUT_DATA_CONNECTION_ID, connectionId).build();
     }
 }

--- a/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectionRefresher.java
@@ -3,7 +3,6 @@ package com.ifttt.location;
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.work.Constraints;
 import androidx.work.Data;

--- a/connect-location/src/main/java/com/ifttt/location/RebootBroadcastReceiver.java
+++ b/connect-location/src/main/java/com/ifttt/location/RebootBroadcastReceiver.java
@@ -16,6 +16,9 @@ public final class RebootBroadcastReceiver extends BroadcastReceiver {
             return;
         }
 
+        if (!ConnectLocation.isInitialized()) {
+            ConnectLocation.init(context);
+        }
         ConnectionRefresher.executeIfExists(context);
     }
 }

--- a/connect-location/src/main/java/com/ifttt/location/RebootBroadcastReceiver.java
+++ b/connect-location/src/main/java/com/ifttt/location/RebootBroadcastReceiver.java
@@ -16,9 +16,6 @@ public final class RebootBroadcastReceiver extends BroadcastReceiver {
             return;
         }
 
-        if (!ConnectLocation.isInitialized()) {
-            ConnectLocation.init(context);
-        }
         ConnectionRefresher.executeIfExists(context);
     }
 }

--- a/connect-location/src/main/java/com/ifttt/location/RebootBroadcastReceiver.java
+++ b/connect-location/src/main/java/com/ifttt/location/RebootBroadcastReceiver.java
@@ -1,0 +1,21 @@
+package com.ifttt.location;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * A {@link BroadcastReceiver} that listens to system's {@link Intent#ACTION_BOOT_COMPLETED} broadcast, and make an
+ * attempt to re-register geo-fences.
+ */
+public final class RebootBroadcastReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (!intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
+            return;
+        }
+
+        ConnectionRefresher.executeIfExists(context);
+    }
+}

--- a/connect-location/src/main/java/com/ifttt/location/UserTokenCache.java
+++ b/connect-location/src/main/java/com/ifttt/location/UserTokenCache.java
@@ -1,0 +1,30 @@
+package com.ifttt.location;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import androidx.annotation.Nullable;
+
+final class UserTokenCache {
+
+    private static final String SHARED_PREF_NAME = "ifttt_user_token_store";
+    private static final String PREF_KEY_USER_TOKEN = "ifttt_key_user_token";
+
+    private final SharedPreferences sharedPreferences;
+
+    UserTokenCache(Context context) {
+        sharedPreferences = context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
+    }
+
+    void store(String userToken) {
+        sharedPreferences.edit().putString(PREF_KEY_USER_TOKEN, userToken).apply();
+    }
+
+    @Nullable
+    String get() {
+        return sharedPreferences.getString(PREF_KEY_USER_TOKEN, null);
+    }
+
+    void clear() {
+        sharedPreferences.edit().remove(PREF_KEY_USER_TOKEN).apply();
+    }
+}

--- a/connect-location/src/test/java/com/ifttt/location/ConnectionRefresherTest.java
+++ b/connect-location/src/test/java/com/ifttt/location/ConnectionRefresherTest.java
@@ -1,0 +1,86 @@
+package com.ifttt.location;
+
+import android.content.Context;
+import android.util.Log;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.work.Configuration;
+import androidx.work.WorkInfo;
+import androidx.work.WorkManager;
+import androidx.work.testing.SynchronousExecutor;
+import androidx.work.testing.WorkManagerTestInitHelper;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public final class ConnectionRefresherTest {
+
+    private Context context;
+
+    @Before
+    public void setUp() throws Exception {
+        context = InstrumentationRegistry.getInstrumentation().getContext();
+        Configuration config = new Configuration.Builder().setMinimumLoggingLevel(Log.DEBUG)
+            .setExecutor(new SynchronousExecutor())
+            .build();
+
+        // Initialize WorkManager for instrumentation tests.
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config);
+    }
+
+    @Test
+    public void shouldAddTagToPeriodicJob() throws ExecutionException, InterruptedException {
+        ConnectionRefresher.schedule(context, "ConnectionID");
+
+        WorkManager workManager = WorkManager.getInstance(context);
+        List<WorkInfo> infoList = workManager.getWorkInfosForUniqueWork(ConnectionRefresher.WORK_ID_CONNECTION_POLLING)
+            .get();
+
+        assertThat(infoList).hasSize(1);
+        assertThat(infoList.get(0).getState()).isEqualTo(WorkInfo.State.ENQUEUED);
+        assertThat(infoList.get(0).getTags()).contains("connection_id:ConnectionID");
+    }
+
+    @Test
+    public void shouldScheduleExecuteJobIfPeriodicIsScheduled() throws ExecutionException, InterruptedException {
+        WorkManager workManager = WorkManager.getInstance(context);
+
+        ConnectionRefresher.schedule(context, "ConnectionID");
+        List<WorkInfo> infoList = workManager.getWorkInfosForUniqueWork(ConnectionRefresher.WORK_ID_CONNECTION_POLLING)
+            .get();
+
+        UUID id = ConnectionRefresher.scheduleOneTimeRefreshWork(workManager, infoList);
+        assertThat(id).isNotNull();
+
+        WorkInfo info = workManager.getWorkInfoById(id).get();
+        assertThat(info.getState()).isEqualTo(WorkInfo.State.ENQUEUED);
+    }
+
+    @Test
+    public void shouldNotScheduledWithCancelledPeriodicJob() throws ExecutionException, InterruptedException {
+        WorkManager workManager = WorkManager.getInstance(context);
+
+        ConnectionRefresher.schedule(context, "ConnectionID");
+        ConnectionRefresher.cancel(context);
+
+        List<WorkInfo> infoList = workManager.getWorkInfosForUniqueWork(ConnectionRefresher.WORK_ID_CONNECTION_POLLING)
+            .get();
+
+        UUID id = ConnectionRefresher.scheduleOneTimeRefreshWork(workManager, infoList);
+        assertThat(id).isNull();
+    }
+
+    @Test
+    public void shouldNotScheduledForIfNoPeriodicJob() {
+        WorkManager workManager = WorkManager.getInstance(context);
+        UUID id = ConnectionRefresher.scheduleOneTimeRefreshWork(workManager, Collections.emptyList());
+        assertThat(id).isNull();
+    }
+}


### PR DESCRIPTION
So that apps can try to activate the geofences outside of the core flows in the app without having to implement a UserTokenProvider.