### PR TITLE
Update OkHttp version on all libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This SDK uses the following libraries as dependencies:
 	* AppCompat
 
 ## Requirement
-* Android SDK version 18 or higher.
+* Android SDK version 21 or higher.
 * Java 8
 
 ## Installation

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.4.20'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
@@ -33,13 +33,13 @@ task clean(type: Delete) {
 
 ext {
     libVersion = '2.3.6'
-    okHttpVersion = '3.14.2'
-    retrofitVersion = '2.6.0'
+    okHttpVersion = '4.9.0'
+    retrofitVersion = '2.6.1'
     moshiVersion = '1.8.0'
     workManagerVersion = '2.3.1'
 
     compileSdkVersion = 29
-    minSdkVersion = 18
+    minSdkVersion = 21
     buildToolsVersion = '29.0.2'
     awarenessVersion = '18.0.1'
     picassoVersion = '2.71828'

--- a/connect-api/build.gradle
+++ b/connect-api/build.gradle
@@ -36,12 +36,12 @@ dependencies {
     api "com.squareup.moshi:moshi-adapters:$moshiVersion"
     api 'androidx.appcompat:appcompat:1.1.0'
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:4.3'
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'androidx.test.ext:truth:1.2.0'
-    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.robolectric:robolectric:4.4'
+    testImplementation 'androidx.test:runner:1.3.0'
+    testImplementation 'androidx.test:core:1.3.0'
+    testImplementation 'androidx.test.ext:truth:1.3.0'
+    testImplementation 'androidx.test.ext:junit:1.1.2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.4.0'
     testImplementation "com.squareup.retrofit2:retrofit-mock:$retrofitVersion"
 }

--- a/connect-location/README.md
+++ b/connect-location/README.md
@@ -14,9 +14,10 @@ IFTTT Connect Location SDK is an add-on library to the [ConnectButton SDK](https
 * [Google Awareness API](https://developers.google.com/awareness)
 
 ## Requirement
-* Android SDK version 18 or higher.
+* Android SDK version 21 or higher.
 * Java 8
 * [ACCESS_FINE_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION) permission.
+* [ACCESS_BACKGROUND_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_BACKGROUND_LOCATION) permission if targeting Android SDK 29+.
 
 ## Installation
 ### Gradle

--- a/connect-location/src/main/AndroidManifest.xml
+++ b/connect-location/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application>


### PR DESCRIPTION
OkHttp v3.14.2 had a bug that will crash when building the Client if the device is running Android 11.

And because we are bumping OkHttp to 4+, we no longer support Android SDK lower than 21.

Also, along with the update, adding ACCESS_BACKGROUND_LOCATION requirement to ConnectLocation and mention it in README.