### PR TITLE
Update date format for occurred at

### DIFF
--- a/connect-location/src/main/java/com/ifttt/location/LocationInfo.java
+++ b/connect-location/src/main/java/com/ifttt/location/LocationInfo.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 final class LocationInfo {
 
-    private static final DateFormat LOCATION_EVENT_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'",
+    private static final DateFormat LOCATION_EVENT_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX",
         Locale.US
     );
 


### PR DESCRIPTION
`Z` is not correct, and we should use X for ISO8601.