### PR TITLE
Fix privacy & terms click events on Android 11+

### DIFF
--- a/connect-button/src/main/AndroidManifest.xml
+++ b/connect-button/src/main/AndroidManifest.xml
@@ -4,4 +4,14 @@
         <activity android:name=".ui.AboutIftttActivity"
             android:theme="@style/AboutIfttt"/>
     </application>
+
+    <queries>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+        </intent>
+    </queries>
+
 </manifest>


### PR DESCRIPTION
We need to specify queries in manifest in order to correctly query PackageManager about the apps that can open the intent.