### PR TITLE
Rebuild ConnectionApiClient with cache token provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           java-version: 1.8
       - name: Run unit tests
-        run: bash ./gradlew test
+        run: bash ./gradlew testDebug

--- a/connect-api/src/test/java/com/ifttt/connect/api/ConnectionApiClientTest.java
+++ b/connect-api/src/test/java/com/ifttt/connect/api/ConnectionApiClientTest.java
@@ -1,0 +1,26 @@
+package com.ifttt.connect.api;
+
+import android.content.Context;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public final class ConnectionApiClientTest {
+
+    @Test
+    public void newBuilderShouldOverrideUserTokenProvider() {
+        UserTokenProvider oldProvider = () -> null;
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
+        ConnectionApiClient client = new ConnectionApiClient.Builder(context, oldProvider).build();
+
+        UserTokenProvider newProvider = () -> "token";
+        ConnectionApiClient newClient = client.newBuilder(newProvider).build();
+
+        assertThat(client).isNotSameInstanceAs(newClient);
+        assertThat(client.userTokenProvider).isNotSameInstanceAs(newClient.userTokenProvider);
+    }
+}

--- a/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
+++ b/connect-location/src/main/java/com/ifttt/location/ConnectLocation.java
@@ -52,7 +52,11 @@ public final class ConnectLocation {
     final ConnectionApiClient connectionApiClient;
 
     public static synchronized ConnectLocation init(Context context, ConnectionApiClient apiClient) {
-        INSTANCE = new ConnectLocation(new AwarenessGeofenceProvider(context.getApplicationContext()), apiClient);
+        ConnectionApiClient.Builder builder = apiClient.newBuilder(new CacheUserTokenProvider(
+            new SharedPreferenceUserTokenCache(context),
+            apiClient.userTokenProvider
+        ));
+        INSTANCE = new ConnectLocation(new AwarenessGeofenceProvider(context.getApplicationContext()), builder.build());
         return INSTANCE;
     }
 


### PR DESCRIPTION
This is to fix an issue with the host app using `ConnectLocation.init(Context, ConnectionApiClient)` and trying to get the user token cache to work.

Currently only if the host app uses `ConnectLocation.init(Context, UserTokenProvider)` can they get the user token cache behavior.